### PR TITLE
Add chip mapping

### DIFF
--- a/src/components/CollectionComponents.tsx
+++ b/src/components/CollectionComponents.tsx
@@ -45,7 +45,7 @@ export function PumpProbeDialog(props: EavaRequest) {
 
   return (
     <React.Fragment>
-      <Button variant="outlined" onClick={handleClickOpen}>
+      <Button size="small" variant="outlined" onClick={handleClickOpen}>
         EAVA calculator
       </Button>
       <Dialog open={open} onClose={handleClose}>
@@ -156,14 +156,18 @@ function OxfordMapSelection(blockList) {
 
 const MapTypes = ["Full Chip", "Lite"];
 
-function OxfordMapComponent() {
+function OxfordMapComponent({
+  setChipMap,
+}: {
+  setChipMap: React.Dispatch<React.SetStateAction<number[]>>;
+}) {
   const [mapType, setMapType] = React.useState<string>(MapTypes[0]);
 
-  const [chipMap, setChipMap] = React.useState<number[]>([]);
+  // const [chipMap, setChipMap] = React.useState<number[]>([]);
 
-  const fromInputMap = (blockList: number[]) => {
-    setChipMap({ chipMap: blockList });
-  };
+  // const fromInputMap = (blockList: number[]) => {
+  //   setChipMap({ chipMap: blockList });
+  // };
 
   return (
     <Box>
@@ -192,80 +196,91 @@ function OxfordMapComponent() {
   );
 }
 
-function CustomMapComponent(dataFromComponent) {
-  const [numWindowsX, setWinX] = React.useState<number>(0);
-  const [numWindowsY, setWinY] = React.useState<number>(0);
-  const [stepSizeX, setStepX] = React.useState<number>(0);
-  const [stepSizeY, setStepY] = React.useState<number>(0);
-
-  const [chipFormat, setChipFormat] = React.useState<number[]>([]);
-
-  const sendChipFormat = () => {
-    dataFromComponent(chipFormat);
-  };
-
+function CustomMapComponent({
+  setWinX,
+  setWinY,
+  setStepX,
+  setStepY,
+}: {
+  setWinX: React.Dispatch<React.SetStateAction<number>>;
+  setWinY: React.Dispatch<React.SetStateAction<number>>;
+  setStepX: React.Dispatch<React.SetStateAction<number>>;
+  setStepY: React.Dispatch<React.SetStateAction<number>>;
+}) {
   return (
     <Box>
       <Stack direction={"column"} alignItems={"center"} spacing={1}>
         <TextField
           size="small"
           label="numWindowsX"
-          defaultValue={numWindowsX}
+          defaultValue={0.0}
           onChange={(e) => setWinX(Number(e.target.value))}
           style={{ width: 150 }}
         />
         <TextField
           size="small"
           label="numWindowsy"
-          defaultValue={numWindowsY}
+          defaultValue={0.0}
           onChange={(e) => setWinY(Number(e.target.value))}
           style={{ width: 150 }}
         />
         <TextField
           size="small"
           label="stepSizeX"
-          defaultValue={stepSizeX}
+          defaultValue={0.0}
           onChange={(e) => setStepX(Number(e.target.value))}
           style={{ width: 150 }}
         />
         <TextField
           size="small"
           label="stepSizeY"
-          defaultValue={stepSizeY}
+          defaultValue={0.0}
           onChange={(e) => setStepY(Number(e.target.value))}
           style={{ width: 150 }}
         />
-        <Button
-          onClick={() =>
-            setChipFormat([
-              numWindowsX,
-              numWindowsY,
-              stepSizeX,
-              stepSizeY,
-            ]).then(() => sendChipFormat())
-          }
-        >
-          Set
-        </Button>
       </Stack>
     </Box>
   );
 }
 
 // TODO Actually return values from components
-export function MapView(chipType: string) {
-  const [chipInfo, setChipInfo] = React.useState<number[]>([]);
+export function MapView({
+  chipType,
+}: {
+  chipType: string;
+}): JSX.Element | null {
+  let chipInfo: number[];
+  // const [chipInfo, setChipInfo] = React.useState<number[]>([]);
 
-  const getInfoFromComponent = (data: number[]) => {
-    setChipInfo(data);
-  };
+  const [chipMap, setChipMap] = React.useState<number[]>([]);
+
+  const [numWindowsX, setWinX] = React.useState<number>(0);
+  const [numWindowsY, setWinY] = React.useState<number>(0);
+  const [stepSizeX, setStepX] = React.useState<number>(0);
+  const [stepSizeY, setStepY] = React.useState<number>(0);
+
+  let component: JSX.Element;
+
   switch (chipType) {
     case "Oxford":
-      return <OxfordMapComponent />;
+      component = <OxfordMapComponent setChipMap={setChipMap} />;
+      chipInfo = chipMap;
+      return component;
     case "OxfordInner":
-      return <OxfordMapComponent />;
+      component = <OxfordMapComponent setChipMap={setChipMap} />;
+      return component;
     case "Custom":
-      return <CustomMapComponent dataFromComponent={getInfoFromComponent} />;
+      component = (
+        <CustomMapComponent
+          setWinX={setWinX}
+          setWinY={setWinY}
+          setStepX={setStepX}
+          setStepY={setStepY}
+        />
+      );
+      chipInfo = [numWindowsX, numWindowsY, stepSizeX, stepSizeY];
+      console.log(chipInfo);
+      return component;
     default:
       return null;
   }

--- a/src/components/CollectionComponents.tsx
+++ b/src/components/CollectionComponents.tsx
@@ -105,7 +105,7 @@ type MapProps = {
   chipType: string;
 };
 
-function OxfordMapSelection() {
+function OxfordMapSelection(blockList) {
   const [dialogOpen, setDialogOpen] = React.useState(false);
 
   const handleClickOpen = () => {
@@ -149,7 +149,7 @@ function OxfordMapSelection() {
       <TextField
         size="small"
         label="selectedBlocks"
-        defaultValue={"Nothing here yet"}
+        defaultValue={select.valueOf()}
         slotProps={{
           input: { readOnly: true },
         }}
@@ -163,6 +163,12 @@ const MapTypes = ["Full Chip", "Lite"];
 
 function OxfordMapComponent() {
   const [mapType, setMapType] = React.useState<string>(MapTypes[0]);
+
+  const [chipMap, setChipMap] = React.useState<number[]>([]);
+
+  const fromInputMap = (blockList: number[]) => {
+    setChipMap(blockList);
+  };
 
   return (
     <Box>
@@ -183,7 +189,9 @@ function OxfordMapComponent() {
             ))}
           </Select>
         </FormControl>
-        {mapType === MapTypes[0] ? null : <OxfordMapSelection />}
+        {mapType === MapTypes[0] ? null : (
+          <OxfordMapSelection blockList={fromInputMap} />
+        )}
       </Stack>
     </Box>
   );
@@ -231,6 +239,7 @@ function CustomMapComponent() {
   );
 }
 
+// TODO Actually return values from components
 export function MapView(props: MapProps) {
   switch (props.chipType) {
     case "Oxford":

--- a/src/components/CollectionComponents.tsx
+++ b/src/components/CollectionComponents.tsx
@@ -192,6 +192,11 @@ export function PumpProbeOptions({
   );
 }
 
+/**
+ * Create list of numbered ToggleButtons to add to a ToggleButtonGroup
+ *
+ * @param {number[]} blocks - list of numbered buttons to add
+ */
 function LiteMapItems({ blocks }: { blocks: number[] }) {
   const btns = blocks.map((block) => (
     <ToggleButton value={block}>
@@ -201,7 +206,12 @@ function LiteMapItems({ blocks }: { blocks: number[] }) {
   return btns;
 }
 
-// Selection like this works but chipmap showing does not update
+/**
+ * Create a Map Selection dialog for Oxford type chips
+ *
+ * @param {number[]} chipMap - list of blocks which will be collected
+ * @param {React.Dispatch} setChipMap - callback to set the chip map state
+ */
 function OxfordMapSelection({
   chipMap,
   setChipMap,

--- a/src/components/CollectionComponents.tsx
+++ b/src/components/CollectionComponents.tsx
@@ -44,6 +44,13 @@ function calculateEAVA(
   return Number(delay.toFixed(4));
 }
 
+/**
+ * Opens a dilog showing the calculated laser delay to set for each EAVA setting, given the laser
+ * exposure time and collection exposure time.
+ *
+ * @param {number} laserDwell - laser exposure time
+ * @param {number} expTime - collection exposure time
+ */
 export function PumpProbeDialog(props: EavaRequest) {
   const [open, setOpen] = React.useState(false);
 
@@ -114,6 +121,15 @@ export function PumpProbeDialog(props: EavaRequest) {
   );
 }
 
+/**
+ * Dynamic component which will show the pump probe options if one of the settings is selected in the
+ * dropdown.
+ *
+ * @param {string} pumpProbe - selected setting
+ * @param {number} laserDwell - laser exposure time
+ * @param {number} expTime - collection exposure time
+ * @returns null if the selected pump probe setting is `NoPP`, a JSX.Element with input text fields otherwise
+ */
 export function PumpProbeOptions({
   pumpProbe,
   laserDwell,

--- a/src/components/CollectionComponents.tsx
+++ b/src/components/CollectionComponents.tsx
@@ -16,33 +16,7 @@ import {
   Tooltip,
 } from "@mui/material";
 import React from "react";
-
-type EavaRequest = {
-  laserDwell: number;
-  expTime: number;
-};
-
-/**
- * Calculate laser delay for EAVA (Excite And Visit Again) pump probe settings.
- * These are the options labeles as "repeat#" in the UI, the number after repeat
- * indicating how many rows are pumped at a time.
- *
- * @param {number} laserDwell - laser exposure time
- * @param {number} expTime - collection exposure time for each window
- * @param {number} factor - number of rows pumped at the time, multiplied by 2
- * @returns {number} The laser delay to set
- */
-function calculateEAVA(
-  laserDwell: number,
-  expTime: number,
-  factor: number
-): number {
-  const movetime: number = 0.008;
-  const windowsPerRow: number = 20;
-  const delay =
-    factor * windowsPerRow * (movetime + (laserDwell + expTime) / 2);
-  return Number(delay.toFixed(4));
-}
+import { calculateEAVA, EavaRequest, MapTypes } from "./params";
 
 /**
  * Opens a dilog showing the calculated laser delay to set for each EAVA setting, given the laser
@@ -340,8 +314,6 @@ function OxfordMapSelection({
     </Stack>
   );
 }
-
-const MapTypes = ["Full Chip", "Lite"];
 
 function OxfordMapComponent({
   chipMap,

--- a/src/components/CollectionComponents.tsx
+++ b/src/components/CollectionComponents.tsx
@@ -13,6 +13,8 @@ import {
   Select,
   Stack,
   TextField,
+  ToggleButton,
+  ToggleButtonGroup,
   Tooltip,
 } from "@mui/material";
 import React from "react";
@@ -176,9 +178,12 @@ export function PumpProbeOptions({
   );
 }
 
+// Selection like this works but chipmap showing does not update
 function OxfordMapSelection({
+  chipMap,
   setChipMap,
 }: {
+  chipMap: number[];
   setChipMap: React.Dispatch<React.SetStateAction<number[]>>;
 }) {
   const [dialogOpen, setDialogOpen] = React.useState(false);
@@ -190,17 +195,73 @@ function OxfordMapSelection({
   const handleClose = () => {
     setDialogOpen(false);
   };
+
+  const handleBlocks = (
+    event: React.MouseEvent<HTMLElement>,
+    newBlocks: number[]
+  ) => {
+    setChipMap(newBlocks);
+  };
+
+  const handleClear = () => {
+    setChipMap([]);
+  };
+
   return (
     <Stack direction={"column"} alignItems={"center"} spacing={2}>
       <Button variant="outlined" onClick={handleClickOpen}>
         Choose Map
       </Button>
-      <Dialog open={dialogOpen} onClose={handleClose}></Dialog>
+      <Dialog open={dialogOpen} onClose={handleClose}>
+        <Stack direction={"row"}>
+          <ToggleButtonGroup
+            orientation="vertical"
+            value={chipMap}
+            onChange={handleBlocks}
+            aria-label="blocks"
+          >
+            <ToggleButton value={1} aria-label="01">
+              01
+              {/* <Button>01</Button> */}
+            </ToggleButton>
+            <ToggleButton value={2} aria-label="02">
+              02
+            </ToggleButton>
+            <ToggleButton value={3} aria-label="02">
+              03
+            </ToggleButton>
+            <ToggleButton value={4} aria-label="02">
+              04
+            </ToggleButton>
+          </ToggleButtonGroup>
+          <ToggleButtonGroup
+            orientation="vertical"
+            value={chipMap}
+            onChange={handleBlocks}
+            aria-label="blocks"
+          >
+            <ToggleButton value={5} aria-label="01">
+              05
+              {/* <Button>01</Button> */}
+            </ToggleButton>
+            <ToggleButton value={6} aria-label="02">
+              06
+            </ToggleButton>
+            <ToggleButton value={7} aria-label="02">
+              07
+            </ToggleButton>
+            <ToggleButton value={8} aria-label="02">
+              08
+            </ToggleButton>
+          </ToggleButtonGroup>
+        </Stack>
+        <Button onClick={handleClear}> Clear Map </Button>
+      </Dialog>
       <TextField
         size="small"
         label="selectedBlocks"
-        defaultValue={[]}
-        // defaultValue={select.valueOf()}
+        value={chipMap.sort((a, b) => a - b)}
+        defaultValue={chipMap}
         slotProps={{
           input: { readOnly: true },
         }}
@@ -213,17 +274,13 @@ function OxfordMapSelection({
 const MapTypes = ["Full Chip", "Lite"];
 
 function OxfordMapComponent({
+  chipMap,
   setChipMap,
 }: {
+  chipMap: number[];
   setChipMap: React.Dispatch<React.SetStateAction<number[]>>;
 }) {
   const [mapType, setMapType] = React.useState<string>(MapTypes[0]);
-
-  // const [chipMap, setChipMap] = React.useState<number[]>([]);
-
-  // const fromInputMap = (blockList: number[]) => {
-  //   setChipMap({ chipMap: blockList });
-  // };
 
   return (
     <Box>
@@ -245,7 +302,7 @@ function OxfordMapComponent({
           </Select>
         </FormControl>
         {mapType === MapTypes[0] ? null : (
-          <OxfordMapSelection setChipMap={setChipMap} />
+          <OxfordMapSelection chipMap={chipMap} setChipMap={setChipMap} />
         )}
       </Stack>
     </Box>
@@ -299,7 +356,6 @@ function CustomMapComponent({
   );
 }
 
-// TODO Actually return values from components
 export function MapView({
   chipType,
 }: {
@@ -318,11 +374,16 @@ export function MapView({
 
   switch (chipType) {
     case "Oxford":
-      component = <OxfordMapComponent setChipMap={setChipMap} />;
+      component = (
+        <OxfordMapComponent chipMap={chipMap} setChipMap={setChipMap} />
+      );
       chipInfo = chipMap;
+      console.log(chipMap);
       return component;
     case "OxfordInner":
-      component = <OxfordMapComponent setChipMap={setChipMap} />;
+      component = (
+        <OxfordMapComponent chipMap={chipMap} setChipMap={setChipMap} />
+      );
       return component;
     case "Custom":
       component = (

--- a/src/components/CollectionComponents.tsx
+++ b/src/components/CollectionComponents.tsx
@@ -18,6 +18,7 @@ import {
 } from "@mui/material";
 import React from "react";
 import { calculateEAVA, EavaRequest, MapTypes } from "./params";
+import { BrushRounded } from "@mui/icons-material";
 
 /**
  * Opens a dilog showing the calculated laser delay to set for each EAVA setting, given the laser
@@ -182,7 +183,9 @@ function LiteMapItems({ blocks }: { blocks: number[] }) {
 }
 
 /**
- * Create a Map Selection dialog for Oxford type chips
+ * Create a Map Selection dialog for Oxford type chips. The numbering of the
+ * individual windows follows the order in which they are collected by the
+ * motion program.
  *
  * @param {number[]} chipMap - list of blocks which will be collected
  * @param {React.Dispatch} setChipMap - callback to set the chip map state
@@ -329,14 +332,16 @@ function OxfordMapSelection({
 }
 
 function OxfordMapComponent({
+  mapType,
   chipMap,
+  setMapType,
   setChipMap,
 }: {
+  mapType: string;
   chipMap: number[];
+  setMapType: React.Dispatch<React.SetStateAction<string>>;
   setChipMap: React.Dispatch<React.SetStateAction<number[]>>;
 }) {
-  const [mapType, setMapType] = React.useState<string>(MapTypes[0]);
-
   return (
     <Box>
       <Stack direction={"column"} spacing={2}>
@@ -367,16 +372,19 @@ function OxfordMapComponent({
 }
 
 function CustomMapComponent({
-  setWinX,
-  setWinY,
-  setStepX,
-  setStepY,
+  setChipFormat,
 }: {
-  setWinX: React.Dispatch<React.SetStateAction<number>>;
-  setWinY: React.Dispatch<React.SetStateAction<number>>;
-  setStepX: React.Dispatch<React.SetStateAction<number>>;
-  setStepY: React.Dispatch<React.SetStateAction<number>>;
+  setChipFormat: React.Dispatch<React.SetStateAction<number[]>>;
 }) {
+  const [numWindowsX, setWinX] = React.useState<number>(0);
+  const [numWindowsY, setWinY] = React.useState<number>(0);
+  const [stepSizeX, setStepX] = React.useState<number>(0);
+  const [stepSizeY, setStepY] = React.useState<number>(0);
+
+  const handleUpdate = () => {
+    setChipFormat([numWindowsX, numWindowsY, stepSizeX, stepSizeY]);
+  };
+
   return (
     <Box>
       <Stack direction={"column"} alignItems={"center"} spacing={1}>
@@ -384,7 +392,7 @@ function CustomMapComponent({
           <TextField
             size="small"
             label="numWindowsX"
-            defaultValue={0.0}
+            value={numWindowsX}
             onChange={(e) => setWinX(Number(e.target.value))}
             style={{ width: 150 }}
           />
@@ -393,7 +401,7 @@ function CustomMapComponent({
           <TextField
             size="small"
             label="numWindowsy"
-            defaultValue={0.0}
+            value={numWindowsY}
             onChange={(e) => setWinY(Number(e.target.value))}
             style={{ width: 150 }}
           />
@@ -402,7 +410,7 @@ function CustomMapComponent({
           <TextField
             size="small"
             label="stepSizeX"
-            defaultValue={0.0}
+            value={stepSizeX}
             onChange={(e) => setStepX(Number(e.target.value))}
             style={{ width: 150 }}
           />
@@ -411,10 +419,15 @@ function CustomMapComponent({
           <TextField
             size="small"
             label="stepSizeY"
-            defaultValue={0.0}
+            value={stepSizeY}
             onChange={(e) => setStepY(Number(e.target.value))}
             style={{ width: 150 }}
           />
+        </Tooltip>
+        <Tooltip title="Set chip format for Custom" placement="right">
+          <Button onClick={handleUpdate} size="small">
+            Set
+          </Button>
         </Tooltip>
       </Stack>
     </Box>
@@ -423,40 +436,35 @@ function CustomMapComponent({
 
 export function MapView({
   chipType,
+  mapType,
+  chipFormat,
+  setMapType,
+  setChipFormat,
 }: {
   chipType: string;
+  mapType: string;
+  chipFormat: number[];
+  setMapType: React.Dispatch<React.SetStateAction<string>>;
+  setChipFormat: React.Dispatch<React.SetStateAction<number[]>>;
 }): JSX.Element | null {
-  let chipInfo: number[];
-
-  const [chipMap, setChipMap] = React.useState<number[]>([]);
-
-  const [numWindowsX, setWinX] = React.useState<number>(0);
-  const [numWindowsY, setWinY] = React.useState<number>(0);
-  const [stepSizeX, setStepX] = React.useState<number>(0);
-  const [stepSizeY, setStepY] = React.useState<number>(0);
-
   let component: JSX.Element;
 
   switch (chipType) {
     case "OxfordInner":
     case "Oxford":
       component = (
-        <OxfordMapComponent chipMap={chipMap} setChipMap={setChipMap} />
-      );
-      chipInfo = chipMap;
-      console.log(chipMap);
-      return component;
-    case "Custom":
-      component = (
-        <CustomMapComponent
-          setWinX={setWinX}
-          setWinY={setWinY}
-          setStepX={setStepX}
-          setStepY={setStepY}
+        <OxfordMapComponent
+          mapType={mapType}
+          chipMap={chipFormat}
+          setMapType={setMapType}
+          setChipMap={setChipFormat}
         />
       );
-      chipInfo = [numWindowsX, numWindowsY, stepSizeX, stepSizeY];
-      console.log(chipInfo);
+      console.log(chipFormat);
+      return component;
+    case "Custom":
+      component = <CustomMapComponent setChipFormat={setChipFormat} />;
+      console.log(chipFormat);
       return component;
     default:
       return null;

--- a/src/components/CollectionComponents.tsx
+++ b/src/components/CollectionComponents.tsx
@@ -167,7 +167,7 @@ function OxfordMapComponent() {
   const [chipMap, setChipMap] = React.useState<number[]>([]);
 
   const fromInputMap = (blockList: number[]) => {
-    setChipMap(blockList);
+    setChipMap({ chipMap: blockList });
   };
 
   return (

--- a/src/components/CollectionComponents.tsx
+++ b/src/components/CollectionComponents.tsx
@@ -135,7 +135,10 @@ export function PumpProbeOptions({
 
   return (
     <Stack spacing={1} direction={"column"}>
-      <Tooltip title="Exposure time for the laser pump, in seconds">
+      <Tooltip
+        title="Exposure time for the laser pump, in seconds"
+        placement="right"
+      >
         <TextField
           size="small"
           label="Laser Dwell (s)"
@@ -144,7 +147,10 @@ export function PumpProbeOptions({
           style={{ width: 150 }}
         />
       </Tooltip>
-      <Tooltip title="Delay time between the laser pump and the collection, in seconds">
+      <Tooltip
+        title="Delay time between the laser pump and the collection, in seconds"
+        placement="right"
+      >
         <TextField
           size="small"
           label="Laser Delay (s)"
@@ -153,7 +159,10 @@ export function PumpProbeOptions({
           style={{ width: 150 }}
         />
       </Tooltip>
-      <Tooltip title="How long to collect before laser pump, if setting is Short2, in seconds">
+      <Tooltip
+        title="How long to collect before laser pump, if setting is Short2, in seconds"
+        placement="right"
+      >
         <TextField
           size="small"
           label="Pre-Pump Exposure Time (s)"

--- a/src/components/CollectionComponents.tsx
+++ b/src/components/CollectionComponents.tsx
@@ -425,7 +425,7 @@ function CustomMapComponent({
           <TextField
             size="small"
             label="numWindowsX"
-            value={numWindowsX}
+            defaultValue={numWindowsX}
             onChange={(e) => setWinX(Number(e.target.value))}
             style={{ width: 150 }}
           />
@@ -434,7 +434,7 @@ function CustomMapComponent({
           <TextField
             size="small"
             label="numWindowsy"
-            value={numWindowsY}
+            defaultValue={numWindowsY}
             onChange={(e) => setWinY(Number(e.target.value))}
             style={{ width: 150 }}
           />
@@ -443,7 +443,7 @@ function CustomMapComponent({
           <TextField
             size="small"
             label="stepSizeX"
-            value={stepSizeX}
+            defaultValue={stepSizeX}
             onChange={(e) => setStepX(Number(e.target.value))}
             style={{ width: 150 }}
           />
@@ -452,7 +452,7 @@ function CustomMapComponent({
           <TextField
             size="small"
             label="stepSizeY"
-            value={stepSizeY}
+            defaultValue={stepSizeY}
             onChange={(e) => setStepY(Number(e.target.value))}
             style={{ width: 150 }}
           />

--- a/src/components/CollectionComponents.tsx
+++ b/src/components/CollectionComponents.tsx
@@ -453,17 +453,13 @@ export function MapView({
   let component: JSX.Element;
 
   switch (chipType) {
+    case "OxfordInner":
     case "Oxford":
       component = (
         <OxfordMapComponent chipMap={chipMap} setChipMap={setChipMap} />
       );
       chipInfo = chipMap;
       console.log(chipMap);
-      return component;
-    case "OxfordInner":
-      component = (
-        <OxfordMapComponent chipMap={chipMap} setChipMap={setChipMap} />
-      );
       return component;
     case "Custom":
       component = (

--- a/src/components/CollectionComponents.tsx
+++ b/src/components/CollectionComponents.tsx
@@ -434,9 +434,7 @@ function CustomMapComponent({
   );
 }
 
-// TODO The fact that chip format is common is a problem because it will
-// hold state when switching between one chip type and the other
-// not that it happens during beamtime BUT it still should be done correctly
+// See https://github.com/DiamondLightSource/mx-daq-ui/issues/30
 export function MapView({
   chipType,
   mapType,

--- a/src/components/CollectionComponents.tsx
+++ b/src/components/CollectionComponents.tsx
@@ -238,9 +238,14 @@ function OxfordMapSelection({
 
   return (
     <Stack direction={"column"} alignItems={"center"} spacing={2}>
-      <Button variant="outlined" onClick={handleClickOpen}>
-        Choose Map
-      </Button>
+      <Tooltip
+        title="Choose which blocks to collect on the map"
+        placement="right"
+      >
+        <Button variant="outlined" onClick={handleClickOpen}>
+          Choose Map
+        </Button>
+      </Tooltip>
       <Dialog open={dialogOpen} onClose={handleClose}>
         <Stack direction={"row"}>
           <ToggleButtonGroup
@@ -310,16 +315,18 @@ function OxfordMapSelection({
         </Stack>
         <Button onClick={handleClear}> Clear Map </Button>
       </Dialog>
-      <TextField
-        size="small"
-        label="selectedBlocks"
-        value={chipMap.sort((a, b) => a - b)}
-        defaultValue={chipMap}
-        slotProps={{
-          input: { readOnly: true },
-        }}
-        style={{ width: 150 }}
-      />
+      <Tooltip title="This will show which blocks are currently selected for collection">
+        <TextField
+          size="small"
+          label="selectedBlocks"
+          value={chipMap.sort((a, b) => a - b)}
+          defaultValue={chipMap}
+          slotProps={{
+            input: { readOnly: true },
+          }}
+          style={{ width: 150 }}
+        />
+      </Tooltip>
     </Stack>
   );
 }
@@ -340,19 +347,21 @@ function OxfordMapComponent({
       <Stack direction={"column"} spacing={2}>
         <FormControl size="small" style={{ width: 150 }}>
           <InputLabel id="map-label">mapType</InputLabel>
-          <Select
-            labelId="map-label"
-            id="map"
-            value={mapType}
-            label="mapType"
-            onChange={(e) => setMapType(String(e.target.value))}
-          >
-            {MapTypes.map((mapType) => (
-              <MenuItem key={mapType} value={mapType}>
-                {mapType}
-              </MenuItem>
-            ))}
-          </Select>
+          <Tooltip title="Select mapping type" placement="right">
+            <Select
+              labelId="map-label"
+              id="map"
+              value={mapType}
+              label="mapType"
+              onChange={(e) => setMapType(String(e.target.value))}
+            >
+              {MapTypes.map((mapType) => (
+                <MenuItem key={mapType} value={mapType}>
+                  {mapType}
+                </MenuItem>
+              ))}
+            </Select>
+          </Tooltip>
         </FormControl>
         {mapType === MapTypes[0] ? null : (
           <OxfordMapSelection chipMap={chipMap} setChipMap={setChipMap} />
@@ -376,34 +385,42 @@ function CustomMapComponent({
   return (
     <Box>
       <Stack direction={"column"} alignItems={"center"} spacing={1}>
-        <TextField
-          size="small"
-          label="numWindowsX"
-          defaultValue={0.0}
-          onChange={(e) => setWinX(Number(e.target.value))}
-          style={{ width: 150 }}
-        />
-        <TextField
-          size="small"
-          label="numWindowsy"
-          defaultValue={0.0}
-          onChange={(e) => setWinY(Number(e.target.value))}
-          style={{ width: 150 }}
-        />
-        <TextField
-          size="small"
-          label="stepSizeX"
-          defaultValue={0.0}
-          onChange={(e) => setStepX(Number(e.target.value))}
-          style={{ width: 150 }}
-        />
-        <TextField
-          size="small"
-          label="stepSizeY"
-          defaultValue={0.0}
-          onChange={(e) => setStepY(Number(e.target.value))}
-          style={{ width: 150 }}
-        />
+        <Tooltip title="Type number of windows in x" placement="right">
+          <TextField
+            size="small"
+            label="numWindowsX"
+            defaultValue={0.0}
+            onChange={(e) => setWinX(Number(e.target.value))}
+            style={{ width: 150 }}
+          />
+        </Tooltip>
+        <Tooltip title="Type number of windows in y" placement="right">
+          <TextField
+            size="small"
+            label="numWindowsy"
+            defaultValue={0.0}
+            onChange={(e) => setWinY(Number(e.target.value))}
+            style={{ width: 150 }}
+          />
+        </Tooltip>
+        <Tooltip title="Type step size between windows in x" placement="right">
+          <TextField
+            size="small"
+            label="stepSizeX"
+            defaultValue={0.0}
+            onChange={(e) => setStepX(Number(e.target.value))}
+            style={{ width: 150 }}
+          />
+        </Tooltip>
+        <Tooltip title="Type step size between windows in y" placement="right">
+          <TextField
+            size="small"
+            label="stepSizeY"
+            defaultValue={0.0}
+            onChange={(e) => setStepY(Number(e.target.value))}
+            style={{ width: 150 }}
+          />
+        </Tooltip>
       </Stack>
     </Box>
   );

--- a/src/components/CollectionComponents.tsx
+++ b/src/components/CollectionComponents.tsx
@@ -114,6 +114,59 @@ export function PumpProbeDialog(props: EavaRequest) {
   );
 }
 
+export function PumpProbeOptions({
+  pumpProbe,
+  laserDwell,
+  expTime,
+  setLaserDwell,
+  setLaserDelay,
+  setPrePumpExp,
+}: {
+  pumpProbe: string;
+  laserDwell: number;
+  expTime: number;
+  setLaserDwell: React.Dispatch<React.SetStateAction<number>>;
+  setLaserDelay: React.Dispatch<React.SetStateAction<number>>;
+  setPrePumpExp: React.Dispatch<React.SetStateAction<number>>;
+}): JSX.Element | null {
+  if (pumpProbe === "NoPP") {
+    return null;
+  }
+
+  return (
+    <Stack spacing={1} direction={"column"}>
+      <Tooltip title="Exposure time for the laser pump, in seconds">
+        <TextField
+          size="small"
+          label="Laser Dwell (s)"
+          defaultValue={laserDwell}
+          onChange={(e) => setLaserDwell(Number(e.target.value))}
+          style={{ width: 150 }}
+        />
+      </Tooltip>
+      <Tooltip title="Delay time between the laser pump and the collection, in seconds">
+        <TextField
+          size="small"
+          label="Laser Delay (s)"
+          defaultValue={0.0}
+          onChange={(e) => setLaserDelay(Number(e.target.value))}
+          style={{ width: 150 }}
+        />
+      </Tooltip>
+      <Tooltip title="How long to collect before laser pump, if setting is Short2, in seconds">
+        <TextField
+          size="small"
+          label="Pre-Pump Exposure Time (s)"
+          defaultValue={0.0}
+          onChange={(e) => setPrePumpExp(Number(e.target.value))}
+          style={{ width: 150 }}
+        />
+      </Tooltip>
+      <PumpProbeDialog laserDwell={laserDwell} expTime={expTime} />
+    </Stack>
+  );
+}
+
 function OxfordMapSelection({
   setChipMap,
 }: {

--- a/src/components/CollectionComponents.tsx
+++ b/src/components/CollectionComponents.tsx
@@ -261,7 +261,7 @@ function OxfordMapSelection({
         placement="right"
       >
         <Button variant="outlined" onClick={handleClickOpen}>
-          Choose Map
+          Configure Map
         </Button>
       </Tooltip>
       <Dialog open={dialogOpen} onClose={handleClose}>

--- a/src/components/CollectionComponents.tsx
+++ b/src/components/CollectionComponents.tsx
@@ -318,7 +318,7 @@ function OxfordMapSelection({
       <Tooltip title="This will show which blocks are currently selected for collection">
         <TextField
           size="small"
-          label="selectedBlocks"
+          label="Selected Blocks"
           value={chipMap.sort((a, b) => a - b)}
           defaultValue={chipMap}
           slotProps={{
@@ -331,6 +331,14 @@ function OxfordMapSelection({
   );
 }
 
+/**
+ * Dynamic component for the map choice for an Oxford chip.
+ * If the mapType is set to Lite, it will show the button to select the blocks
+ * to collect.
+ *
+ * @param {string} mapType - Choice of mapping, could be Full Chip or Lite
+ * @param {number[]} chipMap - Chipmap to be updated in case of Lite map.
+ */
 function OxfordMapComponent({
   mapType,
   chipMap,
@@ -346,13 +354,13 @@ function OxfordMapComponent({
     <Box>
       <Stack direction={"column"} spacing={2}>
         <FormControl size="small" style={{ width: 150 }}>
-          <InputLabel id="map-label">mapType</InputLabel>
+          <InputLabel id="map-label">Map Type</InputLabel>
           <Tooltip title="Select mapping type" placement="right">
             <Select
               labelId="map-label"
               id="map"
               value={mapType}
-              label="mapType"
+              label="Map Type"
               onChange={(e) => setMapType(String(e.target.value))}
             >
               {MapTypes.map((mapType) => (
@@ -371,6 +379,9 @@ function OxfordMapComponent({
   );
 }
 
+/** Component to set the format of a Custom chip: number of windows in x and y
+ * and step size between each window, in mm.
+ */
 function CustomMapComponent({
   setChipFormat,
 }: {
@@ -435,6 +446,7 @@ function CustomMapComponent({
 }
 
 // See https://github.com/DiamondLightSource/mx-daq-ui/issues/30
+/**Open a different Map component based on the selected chip type. */
 export function MapView({
   chipType,
   mapType,

--- a/src/components/CollectionComponents.tsx
+++ b/src/components/CollectionComponents.tsx
@@ -192,6 +192,15 @@ export function PumpProbeOptions({
   );
 }
 
+function LiteMapItems({ blocks }: { blocks: number[] }) {
+  const btns = blocks.map((block) => (
+    <ToggleButton value={block}>
+      {block.toString().padStart(2, "0")}
+    </ToggleButton>
+  ));
+  return btns;
+}
+
 // Selection like this works but chipmap showing does not update
 function OxfordMapSelection({
   chipMap,
@@ -221,10 +230,11 @@ function OxfordMapSelection({
     setChipMap([]);
   };
 
-  const blocks: number[] = [1, 2, 3, 4];
-  const btns = blocks.map((block) => (
-    <ToggleButton value={block}>0{block}</ToggleButton>
-  ));
+  const rangeUp = (start: number, end: number) =>
+    Array.from(Array(end - start + 1).keys()).map((x) => x + start);
+
+  const rangeDown = (start: number, end: number) =>
+    Array.from(Array(start - end + 1).keys()).map((x) => start - x);
 
   return (
     <Stack direction={"column"} alignItems={"center"} spacing={2}>
@@ -239,7 +249,7 @@ function OxfordMapSelection({
             onChange={handleBlocks}
             aria-label="blocks"
           >
-            {btns}
+            <LiteMapItems blocks={rangeUp(1, 8)} />
           </ToggleButtonGroup>
           <ToggleButtonGroup
             orientation="vertical"
@@ -247,18 +257,55 @@ function OxfordMapSelection({
             onChange={handleBlocks}
             aria-label="blocks"
           >
-            <ToggleButton value={5} aria-label="05">
-              05
-            </ToggleButton>
-            <ToggleButton value={6} aria-label="06">
-              06
-            </ToggleButton>
-            <ToggleButton value={7} aria-label="07">
-              07
-            </ToggleButton>
-            <ToggleButton value={8} aria-label="08">
-              08
-            </ToggleButton>
+            <LiteMapItems blocks={rangeDown(16, 9)} />
+          </ToggleButtonGroup>
+          <ToggleButtonGroup
+            orientation="vertical"
+            value={chipMap}
+            onChange={handleBlocks}
+            aria-label="blocks"
+          >
+            <LiteMapItems blocks={rangeUp(17, 24)} />
+          </ToggleButtonGroup>
+          <ToggleButtonGroup
+            orientation="vertical"
+            value={chipMap}
+            onChange={handleBlocks}
+            aria-label="blocks"
+          >
+            <LiteMapItems blocks={rangeDown(32, 25)} />
+          </ToggleButtonGroup>
+          <ToggleButtonGroup
+            orientation="vertical"
+            value={chipMap}
+            onChange={handleBlocks}
+            aria-label="blocks"
+          >
+            <LiteMapItems blocks={rangeUp(33, 40)} />
+          </ToggleButtonGroup>
+          <ToggleButtonGroup
+            orientation="vertical"
+            value={chipMap}
+            onChange={handleBlocks}
+            aria-label="blocks"
+          >
+            <LiteMapItems blocks={rangeDown(48, 41)} />
+          </ToggleButtonGroup>
+          <ToggleButtonGroup
+            orientation="vertical"
+            value={chipMap}
+            onChange={handleBlocks}
+            aria-label="blocks"
+          >
+            <LiteMapItems blocks={rangeUp(49, 56)} />
+          </ToggleButtonGroup>
+          <ToggleButtonGroup
+            orientation="vertical"
+            value={chipMap}
+            onChange={handleBlocks}
+            aria-label="blocks"
+          >
+            <LiteMapItems blocks={rangeDown(64, 57)} />
           </ToggleButtonGroup>
         </Stack>
         <Button onClick={handleClear}> Clear Map </Button>

--- a/src/components/CollectionComponents.tsx
+++ b/src/components/CollectionComponents.tsx
@@ -100,11 +100,6 @@ export function PumpProbeDialog(props: EavaRequest) {
   );
 }
 
-type MapProps = {
-  label: string;
-  chipType: string;
-};
-
 function OxfordMapSelection(blockList) {
   const [dialogOpen, setDialogOpen] = React.useState(false);
 
@@ -197,11 +192,17 @@ function OxfordMapComponent() {
   );
 }
 
-function CustomMapComponent() {
+function CustomMapComponent(dataFromComponent) {
   const [numWindowsX, setWinX] = React.useState<number>(0);
   const [numWindowsY, setWinY] = React.useState<number>(0);
   const [stepSizeX, setStepX] = React.useState<number>(0);
   const [stepSizeY, setStepY] = React.useState<number>(0);
+
+  const [chipFormat, setChipFormat] = React.useState<number[]>([]);
+
+  const sendChipFormat = () => {
+    dataFromComponent(chipFormat);
+  };
 
   return (
     <Box>
@@ -234,20 +235,37 @@ function CustomMapComponent() {
           onChange={(e) => setStepY(Number(e.target.value))}
           style={{ width: 150 }}
         />
+        <Button
+          onClick={() =>
+            setChipFormat([
+              numWindowsX,
+              numWindowsY,
+              stepSizeX,
+              stepSizeY,
+            ]).then(() => sendChipFormat())
+          }
+        >
+          Set
+        </Button>
       </Stack>
     </Box>
   );
 }
 
 // TODO Actually return values from components
-export function MapView(props: MapProps) {
-  switch (props.chipType) {
+export function MapView(chipType: string) {
+  const [chipInfo, setChipInfo] = React.useState<number[]>([]);
+
+  const getInfoFromComponent = (data: number[]) => {
+    setChipInfo(data);
+  };
+  switch (chipType) {
     case "Oxford":
       return <OxfordMapComponent />;
     case "OxfordInner":
       return <OxfordMapComponent />;
     case "Custom":
-      return <CustomMapComponent />;
+      return <CustomMapComponent dataFromComponent={getInfoFromComponent} />;
     default:
       return null;
   }

--- a/src/components/CollectionComponents.tsx
+++ b/src/components/CollectionComponents.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Button,
+  ButtonGroup,
   Dialog,
   DialogContent,
   DialogContentText,
@@ -220,6 +221,11 @@ function OxfordMapSelection({
   const rangeDown = (start: number, end: number) =>
     Array.from(Array(start - end + 1).keys()).map((x) => start - x);
 
+  const handleSelectAll = () => {
+    const newMap = rangeUp(1, 64);
+    setChipMap(newMap);
+  };
+
   return (
     <Stack direction={"column"} alignItems={"center"} spacing={2}>
       <Tooltip
@@ -297,7 +303,14 @@ function OxfordMapSelection({
             <LiteMapItems blocks={rangeDown(64, 57)} />
           </ToggleButtonGroup>
         </Stack>
-        <Button onClick={handleClear}> Clear Map </Button>
+        <ButtonGroup
+          orientation="horizontal"
+          // variant="text"
+          style={{ justifyContent: "center" }}
+        >
+          <Button onClick={handleSelectAll}> Select All </Button>
+          <Button onClick={handleClear}> Clear Map </Button>
+        </ButtonGroup>
       </Dialog>
       <Tooltip title="This will show which blocks are currently selected for collection">
         <TextField

--- a/src/components/CollectionComponents.tsx
+++ b/src/components/CollectionComponents.tsx
@@ -197,7 +197,7 @@ function OxfordMapSelection({
   };
 
   const handleBlocks = (
-    event: React.MouseEvent<HTMLElement>,
+    _event: React.MouseEvent<HTMLElement>,
     newBlocks: number[]
   ) => {
     setChipMap(newBlocks);
@@ -206,6 +206,11 @@ function OxfordMapSelection({
   const handleClear = () => {
     setChipMap([]);
   };
+
+  const blocks: number[] = [1, 2, 3, 4];
+  const btns = blocks.map((block) => (
+    <ToggleButton value={block}>0{block}</ToggleButton>
+  ));
 
   return (
     <Stack direction={"column"} alignItems={"center"} spacing={2}>
@@ -220,19 +225,7 @@ function OxfordMapSelection({
             onChange={handleBlocks}
             aria-label="blocks"
           >
-            <ToggleButton value={1} aria-label="01">
-              01
-              {/* <Button>01</Button> */}
-            </ToggleButton>
-            <ToggleButton value={2} aria-label="02">
-              02
-            </ToggleButton>
-            <ToggleButton value={3} aria-label="02">
-              03
-            </ToggleButton>
-            <ToggleButton value={4} aria-label="02">
-              04
-            </ToggleButton>
+            {btns}
           </ToggleButtonGroup>
           <ToggleButtonGroup
             orientation="vertical"
@@ -240,17 +233,16 @@ function OxfordMapSelection({
             onChange={handleBlocks}
             aria-label="blocks"
           >
-            <ToggleButton value={5} aria-label="01">
+            <ToggleButton value={5} aria-label="05">
               05
-              {/* <Button>01</Button> */}
             </ToggleButton>
-            <ToggleButton value={6} aria-label="02">
+            <ToggleButton value={6} aria-label="06">
               06
             </ToggleButton>
-            <ToggleButton value={7} aria-label="02">
+            <ToggleButton value={7} aria-label="07">
               07
             </ToggleButton>
-            <ToggleButton value={8} aria-label="02">
+            <ToggleButton value={8} aria-label="08">
               08
             </ToggleButton>
           </ToggleButtonGroup>

--- a/src/components/CollectionComponents.tsx
+++ b/src/components/CollectionComponents.tsx
@@ -434,6 +434,9 @@ function CustomMapComponent({
   );
 }
 
+// TODO The fact that chip format is common is a problem because it will
+// hold state when switching between one chip type and the other
+// not that it happens during beamtime BUT it still should be done correctly
 export function MapView({
   chipType,
   mapType,

--- a/src/components/CollectionComponents.tsx
+++ b/src/components/CollectionComponents.tsx
@@ -1,13 +1,11 @@
 import {
   Box,
   Button,
-  Checkbox,
   Dialog,
   DialogContent,
   DialogContentText,
   DialogTitle,
   FormControl,
-  FormControlLabel,
   InputLabel,
   MenuItem,
   Select,

--- a/src/components/CollectionComponents.tsx
+++ b/src/components/CollectionComponents.tsx
@@ -2,6 +2,7 @@ import {
   Box,
   Button,
   ButtonGroup,
+  Checkbox,
   Dialog,
   DialogContent,
   DialogContentText,
@@ -10,6 +11,7 @@ import {
   InputLabel,
   MenuItem,
   Select,
+  FormControlLabel,
   Stack,
   TextField,
   ToggleButton,
@@ -18,7 +20,6 @@ import {
 } from "@mui/material";
 import React from "react";
 import { calculateEAVA, EavaRequest, MapTypes } from "./params";
-import { BrushRounded } from "@mui/icons-material";
 
 /**
  * Opens a dilog showing the calculated laser delay to set for each EAVA setting, given the laser
@@ -104,22 +105,27 @@ export function PumpProbeDialog(props: EavaRequest) {
  * @param {string} pumpProbe - selected setting
  * @param {number} laserDwell - laser exposure time
  * @param {number} expTime - collection exposure time
+ * @param {boolean} checkerPattern - pump in a checkerboard pattern
  * @returns null if the selected pump probe setting is `NoPP`, a JSX.Element with input text fields otherwise
  */
 export function PumpProbeOptions({
   pumpProbe,
   laserDwell,
   expTime,
+  checkerPattern,
   setLaserDwell,
   setLaserDelay,
   setPrePumpExp,
+  setChecked,
 }: {
   pumpProbe: string;
   laserDwell: number;
   expTime: number;
+  checkerPattern: boolean;
   setLaserDwell: React.Dispatch<React.SetStateAction<number>>;
   setLaserDelay: React.Dispatch<React.SetStateAction<number>>;
   setPrePumpExp: React.Dispatch<React.SetStateAction<number>>;
+  setChecked: React.Dispatch<React.SetStateAction<boolean>>;
 }): JSX.Element | null {
   if (pumpProbe === "NoPP") {
     return null;
@@ -162,6 +168,22 @@ export function PumpProbeOptions({
           onChange={(e) => setPrePumpExp(Number(e.target.value))}
           style={{ width: 150 }}
         />
+      </Tooltip>
+      <Tooltip
+        title="If selected, do pump every other well in a checkerboard pattern"
+        placement="right"
+      >
+        <FormControl>
+          <FormControlLabel
+            label="Checker Pattern"
+            control={
+              <Checkbox
+                checked={checkerPattern}
+                onChange={(e) => setChecked(Boolean(e.target.checked))} // NOPE!
+              />
+            }
+          />
+        </FormControl>
       </Tooltip>
       <PumpProbeDialog laserDwell={laserDwell} expTime={expTime} />
     </Stack>

--- a/src/components/CollectionComponents.tsx
+++ b/src/components/CollectionComponents.tsx
@@ -1,10 +1,19 @@
 import {
+  Box,
   Button,
+  Checkbox,
   Dialog,
   DialogContent,
   DialogContentText,
   DialogTitle,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  MenuItem,
+  Select,
   Stack,
+  TextField,
+  ToggleButton,
 } from "@mui/material";
 import React from "react";
 
@@ -89,4 +98,148 @@ export function PumpProbeDialog(props: EavaRequest) {
       </Dialog>
     </React.Fragment>
   );
+}
+
+type MapProps = {
+  label: string;
+  chipType: string;
+};
+
+function OxfordMapSelection() {
+  const [dialogOpen, setDialogOpen] = React.useState(false);
+
+  const handleClickOpen = () => {
+    setDialogOpen(true);
+  };
+
+  const handleClose = () => {
+    setDialogOpen(false);
+  };
+
+  const [select, setSelected] = React.useState(false);
+
+  const handleSelection = (
+    event: React.MouseEvent<HTMLElement>,
+    newSelect: boolean | null
+  ) => {
+    if (newSelect !== null) {
+      setSelected(newSelect);
+    }
+  };
+
+  return (
+    <Stack direction={"column"} alignItems={"center"} spacing={2}>
+      <Button variant="outlined" onClick={handleClickOpen}>
+        Choose Map
+      </Button>
+      <Dialog open={dialogOpen} onClose={handleClose}>
+        <DialogTitle>Choose blocks on Oxford chip</DialogTitle>
+        <DialogContent>
+          {/* <Box>Buttons here</Box> */}
+          <ToggleButton
+            value="01"
+            selected={select}
+            onClick={(e) => handleSelection(e, true)}
+            aria-label="block1"
+          >
+            01
+          </ToggleButton>
+        </DialogContent>
+      </Dialog>
+      <TextField
+        size="small"
+        label="selectedBlocks"
+        defaultValue={"Nothing here yet"}
+        slotProps={{
+          input: { readOnly: true },
+        }}
+        style={{ width: 150 }}
+      />
+    </Stack>
+  );
+}
+
+const MapTypes = ["Full Chip", "Lite"];
+
+function OxfordMapComponent() {
+  const [mapType, setMapType] = React.useState<string>(MapTypes[0]);
+
+  return (
+    <Box>
+      <Stack direction={"column"} spacing={2}>
+        <FormControl size="small" style={{ width: 150 }}>
+          <InputLabel id="map-label">mapType</InputLabel>
+          <Select
+            labelId="map-label"
+            id="map"
+            value={mapType}
+            label="mapType"
+            onChange={(e) => setMapType(String(e.target.value))}
+          >
+            {MapTypes.map((mapType) => (
+              <MenuItem key={mapType} value={mapType}>
+                {mapType}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        {mapType === MapTypes[0] ? null : <OxfordMapSelection />}
+      </Stack>
+    </Box>
+  );
+}
+
+function CustomMapComponent() {
+  const [numWindowsX, setWinX] = React.useState<number>(0);
+  const [numWindowsY, setWinY] = React.useState<number>(0);
+  const [stepSizeX, setStepX] = React.useState<number>(0);
+  const [stepSizeY, setStepY] = React.useState<number>(0);
+
+  return (
+    <Box>
+      <Stack direction={"column"} alignItems={"center"} spacing={1}>
+        <TextField
+          size="small"
+          label="numWindowsX"
+          defaultValue={numWindowsX}
+          onChange={(e) => setWinX(Number(e.target.value))}
+          style={{ width: 150 }}
+        />
+        <TextField
+          size="small"
+          label="numWindowsy"
+          defaultValue={numWindowsY}
+          onChange={(e) => setWinY(Number(e.target.value))}
+          style={{ width: 150 }}
+        />
+        <TextField
+          size="small"
+          label="stepSizeX"
+          defaultValue={stepSizeX}
+          onChange={(e) => setStepX(Number(e.target.value))}
+          style={{ width: 150 }}
+        />
+        <TextField
+          size="small"
+          label="stepSizeY"
+          defaultValue={stepSizeY}
+          onChange={(e) => setStepY(Number(e.target.value))}
+          style={{ width: 150 }}
+        />
+      </Stack>
+    </Box>
+  );
+}
+
+export function MapView(props: MapProps) {
+  switch (props.chipType) {
+    case "Oxford":
+      return <OxfordMapComponent />;
+    case "OxfordInner":
+      return <OxfordMapComponent />;
+    case "Custom":
+      return <CustomMapComponent />;
+    default:
+      return null;
+  }
 }

--- a/src/components/CollectionComponents.tsx
+++ b/src/components/CollectionComponents.tsx
@@ -12,8 +12,11 @@ import {
   MenuItem,
   Select,
   Stack,
+  styled,
   TextField,
   ToggleButton,
+  ToggleButtonGroup,
+  toggleButtonGroupClasses,
 } from "@mui/material";
 import React from "react";
 
@@ -100,7 +103,11 @@ export function PumpProbeDialog(props: EavaRequest) {
   );
 }
 
-function OxfordMapSelection(blockList) {
+function OxfordMapSelection({
+  setChipMap,
+}: {
+  setChipMap: React.Dispatch<React.SetStateAction<number[]>>;
+}) {
   const [dialogOpen, setDialogOpen] = React.useState(false);
 
   const handleClickOpen = () => {
@@ -110,41 +117,17 @@ function OxfordMapSelection(blockList) {
   const handleClose = () => {
     setDialogOpen(false);
   };
-
-  const [select, setSelected] = React.useState(false);
-
-  const handleSelection = (
-    event: React.MouseEvent<HTMLElement>,
-    newSelect: boolean | null
-  ) => {
-    if (newSelect !== null) {
-      setSelected(newSelect);
-    }
-  };
-
   return (
     <Stack direction={"column"} alignItems={"center"} spacing={2}>
       <Button variant="outlined" onClick={handleClickOpen}>
         Choose Map
       </Button>
-      <Dialog open={dialogOpen} onClose={handleClose}>
-        <DialogTitle>Choose blocks on Oxford chip</DialogTitle>
-        <DialogContent>
-          {/* <Box>Buttons here</Box> */}
-          <ToggleButton
-            value="01"
-            selected={select}
-            onClick={(e) => handleSelection(e, true)}
-            aria-label="block1"
-          >
-            01
-          </ToggleButton>
-        </DialogContent>
-      </Dialog>
+      <Dialog open={dialogOpen} onClose={handleClose}></Dialog>
       <TextField
         size="small"
         label="selectedBlocks"
-        defaultValue={select.valueOf()}
+        defaultValue={[]}
+        // defaultValue={select.valueOf()}
         slotProps={{
           input: { readOnly: true },
         }}
@@ -189,7 +172,7 @@ function OxfordMapComponent({
           </Select>
         </FormControl>
         {mapType === MapTypes[0] ? null : (
-          <OxfordMapSelection blockList={fromInputMap} />
+          <OxfordMapSelection setChipMap={setChipMap} />
         )}
       </Stack>
     </Box>
@@ -250,7 +233,6 @@ export function MapView({
   chipType: string;
 }): JSX.Element | null {
   let chipInfo: number[];
-  // const [chipInfo, setChipInfo] = React.useState<number[]>([]);
 
   const [chipMap, setChipMap] = React.useState<number[]>([]);
 

--- a/src/components/params.ts
+++ b/src/components/params.ts
@@ -1,0 +1,42 @@
+export const chipTypes = ["Oxford", "OxfordInner", "Custom", "MISP"];
+
+export const MapTypes = ["Full Chip", "Lite"];
+
+export const pumpProbeMode = [
+  "NoPP",
+  "Short1",
+  "Short2",
+  "Repeat1",
+  "Repeat2",
+  "Repeat3",
+  "Repeat5",
+  "Repeat10",
+  "Medium1",
+];
+
+export type EavaRequest = {
+  laserDwell: number;
+  expTime: number;
+};
+
+/**
+ * Calculate laser delay for EAVA (Excite And Visit Again) pump probe settings.
+ * These are the options labeles as "repeat#" in the UI, the number after repeat
+ * indicating how many rows are pumped at a time.
+ *
+ * @param {number} laserDwell - laser exposure time
+ * @param {number} expTime - collection exposure time for each window
+ * @param {number} factor - number of rows pumped at the time, multiplied by 2
+ * @returns {number} The laser delay to set
+ */
+export function calculateEAVA(
+  laserDwell: number,
+  expTime: number,
+  factor: number
+): number {
+  const movetime: number = 0.008;
+  const windowsPerRow: number = 20;
+  const delay =
+    factor * windowsPerRow * (movetime + (laserDwell + expTime) / 2);
+  return Number(delay.toFixed(4));
+}

--- a/src/screens/CollectionPanel.tsx
+++ b/src/screens/CollectionPanel.tsx
@@ -1,9 +1,7 @@
 import {
   Box,
   Button,
-  Checkbox,
   FormControl,
-  FormControlLabel,
   Grid2,
   InputLabel,
   MenuItem,
@@ -217,22 +215,8 @@ function CollectionInput() {
             </Tooltip>
           </Stack>
         </Grid2>
-        {/* See https://github.com/DiamondLightSource/mx-daq-ui/issues/25 */}
         <Grid2 size={3}>
           <Stack spacing={1} direction={"column"}>
-            <Tooltip title="Select for drop on chip" placement="right">
-              <FormControl>
-                <FormControlLabel
-                  label="Checker Pattern"
-                  control={
-                    <Checkbox
-                      checked={checkerPattern}
-                      onChange={(e) => setChecked(Boolean(e.target.checked))} // NOPE!
-                    />
-                  }
-                />
-              </FormControl>
-            </Tooltip>
             <Tooltip
               title="Is this a pump probe experiment? Choose the setting."
               placement="right"
@@ -258,9 +242,11 @@ function CollectionInput() {
               pumpProbe={pumpProbe}
               laserDwell={laserDwell}
               expTime={expTime}
+              checkerPattern={checkerPattern}
               setLaserDwell={setLaserDwell}
               setLaserDelay={setLaserDelay}
               setPrePumpExp={setPrePumpExp}
+              setChecked={setChecked}
             />
           </Stack>
         </Grid2>

--- a/src/screens/CollectionPanel.tsx
+++ b/src/screens/CollectionPanel.tsx
@@ -95,11 +95,11 @@ function RunButtons(props: ParametersProp) {
               transmission: props.transFract,
               n_shots: props.nShots,
               chip_type: props.chipType,
-              checker_pattern: props.checkerPattern, // .valueOf(),
+              checker_pattern: props.checkerPattern,
               pump_probe: props.pumpProbe,
-              laser_dwell: props.pumpInputs[0], //laserDwell,
-              laser_delay: props.pumpInputs[1], //laserDelay,
-              pre_pump: props.pumpInputs[2], //prePump,
+              laser_dwell: props.pumpInputs[0],
+              laser_delay: props.pumpInputs[1],
+              pre_pump: props.pumpInputs[2],
             })
           }
         >

--- a/src/screens/CollectionPanel.tsx
+++ b/src/screens/CollectionPanel.tsx
@@ -19,7 +19,7 @@ import {
   abortCurrentPlan,
   submitAndRunPlanImmediately,
 } from "../blueapi/blueapi";
-import { chipTypes, pumpProbeMode } from "../components/params";
+import { chipTypes, MapTypes, pumpProbeMode } from "../components/params";
 
 function FixedInputs() {
   return (
@@ -62,6 +62,8 @@ type ParametersProps = {
   transFract: number;
   nShots: number;
   chipType: string;
+  mapType: string;
+  chipFormat: number[];
   checkerPattern: boolean;
   pumpProbe: string;
   pumpInputs: number[];
@@ -86,6 +88,8 @@ function RunButtons(props: ParametersProps) {
                 transmission: props.transFract,
                 n_shots: props.nShots,
                 chip_type: props.chipType,
+                map_type: props.mapType,
+                chip_format: props.chipFormat,
                 checker_pattern: props.checkerPattern,
                 pump_probe: props.pumpProbe,
                 laser_dwell: props.pumpInputs[0],
@@ -120,6 +124,9 @@ function CollectionInput() {
   const [prePump, setPrePumpExp] = React.useState<number>(0.0);
   const [checkerPattern, setChecked] = React.useState(false);
   const [chipType, setChipType] = React.useState<string>(chipTypes[0]);
+
+  const [mapType, setMapType] = React.useState<string>(MapTypes[0]);
+  const [chipFormat, setChipFormat] = React.useState<number[]>([]);
 
   return (
     <Box sx={{ flexGrow: 1 }}>
@@ -269,7 +276,13 @@ function CollectionInput() {
               </FormControl>
             </Tooltip>
             {/* See https://github.com/DiamondLightSource/mx-daq-ui/issues/3?issue=DiamondLightSource%7Cmx-daq-ui%7C5 */}
-            <MapView chipType={chipType} />
+            <MapView
+              chipType={chipType}
+              mapType={mapType}
+              chipFormat={chipFormat}
+              setMapType={setMapType}
+              setChipFormat={setChipFormat}
+            />
           </Stack>
         </Grid2>
         <RunButtons
@@ -280,6 +293,8 @@ function CollectionInput() {
           transFract={trans}
           nShots={shots}
           chipType={chipType}
+          mapType={mapType}
+          chipFormat={chipFormat}
           checkerPattern={checkerPattern.valueOf()}
           pumpProbe={pumpProbe}
           pumpInputs={[laserDwell, laserDelay, prePump]}

--- a/src/screens/CollectionPanel.tsx
+++ b/src/screens/CollectionPanel.tsx
@@ -21,6 +21,9 @@ import {
 } from "../blueapi/blueapi";
 import { chipTypes, MapTypes, pumpProbeMode } from "../components/params";
 
+/**
+ * A couple of read-only boxes showing what the visit and detector in use are.
+ */
 function FixedInputs() {
   return (
     <Grid2 size={12}>
@@ -69,6 +72,11 @@ type ParametersProps = {
   pumpInputs: number[];
 };
 
+/**
+ * Component to add Start and Abort buttons to collection panel.
+ *
+ * @param {ParametersProps} props
+ */
 function RunButtons(props: ParametersProps) {
   console.log(props);
   return (
@@ -111,6 +119,7 @@ function RunButtons(props: ParametersProps) {
   );
 }
 
+/**Main collection input window for the panel. */
 function CollectionInput() {
   const [subDir, setSubDir] = React.useState<string>("path/to/dir");
   const [chipName, setChipName] = React.useState<string>("test");

--- a/src/screens/CollectionPanel.tsx
+++ b/src/screens/CollectionPanel.tsx
@@ -14,29 +14,12 @@ import {
 } from "@mui/material";
 import { PvComponent, PvItem } from "../pv/PvComponent";
 import React from "react";
-import {
-  MapView,
-  PumpProbeDialog,
-  PumpProbeOptions,
-} from "../components/CollectionComponents";
+import { MapView, PumpProbeOptions } from "../components/CollectionComponents";
 import {
   abortCurrentPlan,
   submitAndRunPlanImmediately,
 } from "../blueapi/blueapi";
-
-const pumpProbeMode = [
-  "NoPP",
-  "Short1",
-  "Short2",
-  "Repeat1",
-  "Repeat2",
-  "Repeat3",
-  "Repeat5",
-  "Repeat10",
-  "Medium1",
-];
-
-const chipTypes = ["Oxford", "OxfordInner", "Custom", "MISP"];
+import { chipTypes, pumpProbeMode } from "../components/params";
 
 function FixedInputs() {
   return (
@@ -71,7 +54,7 @@ function FixedInputs() {
   );
 }
 
-type ParametersProp = {
+type ParametersProps = {
   subDir: string;
   chipName: string;
   expTime: number;
@@ -84,7 +67,7 @@ type ParametersProp = {
   pumpInputs: number[];
 };
 
-function RunButtons(props: ParametersProp) {
+function RunButtons(props: ParametersProps) {
   console.log(props);
   return (
     <Grid2 size={12}>

--- a/src/screens/CollectionPanel.tsx
+++ b/src/screens/CollectionPanel.tsx
@@ -270,7 +270,6 @@ function CollectionInput() {
                 </Select>
               </FormControl>
             </Tooltip>
-            {/* See https://github.com/DiamondLightSource/mx-daq-ui/issues/3?issue=DiamondLightSource%7Cmx-daq-ui%7C5 */}
             <MapView
               chipType={chipType}
               mapType={mapType}

--- a/src/screens/CollectionPanel.tsx
+++ b/src/screens/CollectionPanel.tsx
@@ -143,7 +143,7 @@ function CollectionInput() {
           <Stack direction={"column"} spacing={1} alignItems={"center"}>
             <Tooltip
               title="Location inside visit directory to save data"
-              placement="right"
+              placement="left"
             >
               <TextField
                 size="small"
@@ -155,7 +155,7 @@ function CollectionInput() {
             </Tooltip>
             <Tooltip
               title="Chip identifier, this will be used as filename"
-              placement="right"
+              placement="left"
             >
               <TextField
                 size="small"
@@ -167,7 +167,7 @@ function CollectionInput() {
             </Tooltip>
             <Tooltip
               title="How many consecutive times each window should be collected."
-              placement="right"
+              placement="left"
             >
               <TextField
                 size="small"
@@ -179,7 +179,7 @@ function CollectionInput() {
             </Tooltip>
             <Tooltip
               title="Exposure time for each window, in seconds"
-              placement="right"
+              placement="left"
             >
               <TextField
                 size="small"
@@ -191,7 +191,7 @@ function CollectionInput() {
             </Tooltip>
             <Tooltip
               title="Request transmission for collection, expressed as a fraction"
-              placement="right"
+              placement="left"
             >
               <TextField
                 size="small"
@@ -203,7 +203,7 @@ function CollectionInput() {
             </Tooltip>
             <Tooltip
               title="Distance to move the detector y stage to, in millimeters"
-              placement="right"
+              placement="left"
             >
               <TextField
                 size="small"

--- a/src/screens/CollectionPanel.tsx
+++ b/src/screens/CollectionPanel.tsx
@@ -14,7 +14,11 @@ import {
 } from "@mui/material";
 import { PvComponent, PvItem } from "../pv/PvComponent";
 import React from "react";
-import { MapView, PumpProbeDialog } from "../components/CollectionComponents";
+import {
+  MapView,
+  PumpProbeDialog,
+  PumpProbeOptions,
+} from "../components/CollectionComponents";
 import {
   abortCurrentPlan,
   submitAndRunPlanImmediately,
@@ -126,7 +130,7 @@ function CollectionInput() {
   const [pumpProbe, setPumpProbe] = React.useState<string>(pumpProbeMode[0]);
   const [laserDwell, setLaserDwell] = React.useState<number>(0.0);
   const [laserDelay, setLaserDelay] = React.useState<number>(0.0);
-  const [prePump, setPerPumpExp] = React.useState<number>(0.0);
+  const [prePump, setPrePumpExp] = React.useState<number>(0.0);
   const [checkerPattern, setChecked] = React.useState(false);
   const [chipType, setChipType] = React.useState<string>(chipTypes[0]);
 
@@ -195,6 +199,19 @@ function CollectionInput() {
         {/* See https://github.com/DiamondLightSource/mx-daq-ui/issues/25 */}
         <Grid2 size={3}>
           <Stack spacing={1} direction={"column"}>
+            <Tooltip title="Select for drop on chip">
+              <FormControl>
+                <FormControlLabel
+                  label="Checker Pattern"
+                  control={
+                    <Checkbox
+                      checked={checkerPattern}
+                      onChange={(e) => setChecked(Boolean(e.target.checked))} // NOPE!
+                    />
+                  }
+                />
+              </FormControl>
+            </Tooltip>
             <Tooltip title="Is this a pump probe experiment? Choose the setting.">
               <FormControl size="small" style={{ width: 150 }}>
                 <InputLabel id="pp-label">Pump Probe</InputLabel>
@@ -213,48 +230,14 @@ function CollectionInput() {
                 </Select>
               </FormControl>
             </Tooltip>
-            {/*TODO See https://github.com/DiamondLightSource/mx-daq-ui/issues/3?issue=DiamondLightSource%7Cmx-daq-ui%7C16 */}
-            <Tooltip title="Exposure time for the laser pump, in seconds">
-              <TextField
-                size="small"
-                label="Laser Dwell (s)"
-                defaultValue={laserDwell}
-                onChange={(e) => setLaserDwell(Number(e.target.value))}
-                style={{ width: 150 }}
-              />
-            </Tooltip>
-            <Tooltip title="Delay time between the laser pump and the collection, in seconds">
-              <TextField
-                size="small"
-                label="Laser Delay (s)"
-                defaultValue={laserDelay}
-                onChange={(e) => setLaserDelay(Number(e.target.value))}
-                style={{ width: 150 }}
-              />
-            </Tooltip>
-            <Tooltip title="How long to collect before laser pump, if setting is Short2, in seconds">
-              <TextField
-                size="small"
-                label="Pre-Pump Exposure Time (s)"
-                defaultValue={prePump}
-                onChange={(e) => setPerPumpExp(Number(e.target.value))}
-                style={{ width: 150 }}
-              />
-            </Tooltip>
-            <Tooltip title="Select for drop on chip">
-              <FormControl>
-                <FormControlLabel
-                  label="Checker Pattern"
-                  control={
-                    <Checkbox
-                      checked={checkerPattern}
-                      onChange={(e) => setChecked(Boolean(e.target.checked))} // NOPE!
-                    />
-                  }
-                />
-              </FormControl>
-            </Tooltip>
-            <PumpProbeDialog laserDwell={laserDwell} expTime={expTime} />
+            <PumpProbeOptions
+              pumpProbe={pumpProbe}
+              laserDwell={laserDwell}
+              expTime={expTime}
+              setLaserDwell={setLaserDwell}
+              setLaserDelay={setLaserDelay}
+              setPrePumpExp={setPrePumpExp}
+            />
           </Stack>
         </Grid2>
         <Grid2 size={4.5}>

--- a/src/screens/CollectionPanel.tsx
+++ b/src/screens/CollectionPanel.tsx
@@ -93,6 +93,7 @@ function RunButtons(props: ParametersProp) {
           https://github.com/DiamondLightSource/mx-daq-ui/issues/3?issue=DiamondLightSource%7Cmx-daq-ui%7C18 */}
         <Tooltip title="Start fixed target collection" placement="bottom">
           <Button
+            variant="outlined"
             onClick={() =>
               submitAndRunPlanImmediately("gui_set_parameters", {
                 sub_dir: props.subDir,
@@ -110,11 +111,13 @@ function RunButtons(props: ParametersProp) {
               })
             }
           >
-            Run (for now just set)!
+            Start!
           </Button>
         </Tooltip>
         <Tooltip title="Abort current operation" placement="bottom">
-          <Button onClick={() => abortCurrentPlan()}>Abort!</Button>
+          <Button variant="outlined" onClick={() => abortCurrentPlan()}>
+            Abort!
+          </Button>
         </Tooltip>
       </Stack>
     </Grid2>
@@ -286,19 +289,19 @@ function CollectionInput() {
             <MapView chipType={chipType} />
           </Stack>
         </Grid2>
+        <RunButtons
+          subDir={subDir}
+          chipName={chipName}
+          expTime={expTime}
+          detDist={detDist}
+          transFract={trans}
+          nShots={shots}
+          chipType={chipType}
+          checkerPattern={checkerPattern.valueOf()}
+          pumpProbe={pumpProbe}
+          pumpInputs={[laserDwell, laserDelay, prePump]}
+        />
       </Grid2>
-      <RunButtons
-        subDir={subDir}
-        chipName={chipName}
-        expTime={expTime}
-        detDist={detDist}
-        transFract={trans}
-        nShots={shots}
-        chipType={chipType}
-        checkerPattern={checkerPattern.valueOf()}
-        pumpProbe={pumpProbe}
-        pumpInputs={[laserDwell, laserDelay, prePump]}
-      />
     </Box>
   );
 }

--- a/src/screens/CollectionPanel.tsx
+++ b/src/screens/CollectionPanel.tsx
@@ -33,6 +33,84 @@ const pumpProbeMode = [
 
 const chipTypes = ["Oxford", "OxfordInner", "Custom", "MISP"];
 
+function FixedInputs() {
+  return (
+    <Grid2 size={12}>
+      <PvComponent
+        label="Visit"
+        pv="ca://ME14E-MO-IOC-01:GP100"
+        render={({ label, value }: PvItem) => {
+          return (
+            <Box>
+              <p>
+                <b>{label}:</b> {value?.toString().slice(7)}
+              </p>
+            </Box>
+          );
+        }}
+      />
+      <PvComponent
+        label="Detector in use"
+        pv="ca://ME14E-MO-IOC-01:GP101"
+        render={({ label, value }: PvItem) => {
+          return (
+            <Box>
+              <p>
+                <b>{label}:</b> {value?.toString().slice(7)}
+              </p>
+            </Box>
+          );
+        }}
+      />
+    </Grid2>
+  );
+}
+
+type ParametersProp = {
+  subDir: string;
+  chipName: string;
+  expTime: number;
+  detDist: number;
+  transFract: number;
+  nShots: number;
+  chipType: string;
+  checkerPattern: boolean;
+  pumpProbe: string;
+  pumpInputs: number[];
+};
+
+function RunButtons(props: ParametersProp) {
+  return (
+    <Grid2 size={12}>
+      <Stack direction={"row"} spacing={10} justifyContent={"center"}>
+        {/* See
+          https://github.com/DiamondLightSource/mx-daq-ui/issues/3?issue=DiamondLightSource%7Cmx-daq-ui%7C18 */}
+        <Button
+          onClick={() =>
+            submitAndRunPlanImmediately("gui_set_parameters", {
+              sub_dir: props.subDir,
+              chip_name: props.chipName,
+              exp_time: props.expTime,
+              det_dist: props.detDist,
+              transmission: props.transFract,
+              n_shots: props.nShots,
+              chip_type: props.chipType,
+              checker_pattern: props.checkerPattern, // .valueOf(),
+              pump_probe: props.pumpProbe,
+              laser_dwell: props.pumpInputs[0], //laserDwell,
+              laser_delay: props.pumpInputs[1], //laserDelay,
+              pre_pump: props.pumpInputs[2], //prePump,
+            })
+          }
+        >
+          Run (for now just set)!
+        </Button>
+        <Button onClick={() => abortCurrentPlan()}>Abort!</Button>
+      </Stack>
+    </Grid2>
+  );
+}
+
 function CollectionInput() {
   const [subDir, setSubDir] = React.useState<string>("path/to/dir");
   const [chipName, setChipName] = React.useState<string>("test");
@@ -50,34 +128,7 @@ function CollectionInput() {
   return (
     <Box sx={{ flexGrow: 1 }}>
       <Grid2 container spacing={2}>
-        <Grid2 size={12}>
-          <PvComponent
-            label="Visit"
-            pv="ca://ME14E-MO-IOC-01:GP100"
-            render={({ label, value }: PvItem) => {
-              return (
-                <Box>
-                  <p>
-                    <b>{label}:</b> {value?.toString().slice(7)}
-                  </p>
-                </Box>
-              );
-            }}
-          />
-          <PvComponent
-            label="Detector in use"
-            pv="ca://ME14E-MO-IOC-01:GP101"
-            render={({ label, value }: PvItem) => {
-              return (
-                <Box>
-                  <p>
-                    <b>{label}:</b> {value?.toString().slice(7)}
-                  </p>
-                </Box>
-              );
-            }}
-          />
-        </Grid2>
+        <FixedInputs />
         <Grid2 size={4.5}>
           <Stack direction={"column"} spacing={1} alignItems={"center"}>
             <TextField
@@ -170,7 +221,7 @@ function CollectionInput() {
                 control={
                   <Checkbox
                     checked={checkerPattern}
-                    onChange={(e) => setChecked(Boolean(e.target.checked))} // NOPE!
+                    onChange={(e) => setChecked(Boolean(e.target.checked))}
                   />
                 }
               />
@@ -201,33 +252,18 @@ function CollectionInput() {
           </Stack>
         </Grid2>
       </Grid2>
-      <Grid2 size={12}>
-        <Stack direction={"row"} spacing={"5"} justifyContent={"center"}>
-          {/* See
-          https://github.com/DiamondLightSource/mx-daq-ui/issues/3?issue=DiamondLightSource%7Cmx-daq-ui%7C18 */}
-          <Button
-            onClick={() =>
-              submitAndRunPlanImmediately("gui_set_parameters", {
-                sub_dir: subDir,
-                chip_name: chipName,
-                exp_time: expTime,
-                det_dist: detDist,
-                transmission: trans,
-                n_shots: shots,
-                chip_type: chipType,
-                checker_pattern: checkerPattern.valueOf(),
-                pump_probe: pumpProbe,
-                laser_dwell: laserDwell,
-                laser_delay: laserDelay,
-                pre_pump: prePump,
-              })
-            }
-          >
-            Run (for now just set)!
-          </Button>
-          <Button onClick={() => abortCurrentPlan()}>Abort!</Button>
-        </Stack>
-      </Grid2>
+      <RunButtons
+        subDir={subDir}
+        chipName={chipName}
+        expTime={expTime}
+        detDist={detDist}
+        transFract={trans}
+        nShots={shots}
+        chipType={chipType}
+        checkerPattern={checkerPattern.valueOf()}
+        pumpProbe={pumpProbe}
+        pumpInputs={[laserDwell, laserDelay, prePump]}
+      />
     </Box>
   );
 }

--- a/src/screens/CollectionPanel.tsx
+++ b/src/screens/CollectionPanel.tsx
@@ -90,7 +90,7 @@ function RunButtons(props: ParametersProp) {
       <Stack direction={"row"} spacing={8} justifyContent={"center"}>
         {/* See
           https://github.com/DiamondLightSource/mx-daq-ui/issues/3?issue=DiamondLightSource%7Cmx-daq-ui%7C18 */}
-        <Tooltip title="Start fixed target collection">
+        <Tooltip title="Start fixed target collection" placement="bottom">
           <Button
             onClick={() =>
               submitAndRunPlanImmediately("gui_set_parameters", {
@@ -112,7 +112,7 @@ function RunButtons(props: ParametersProp) {
             Run (for now just set)!
           </Button>
         </Tooltip>
-        <Tooltip title="Abort current operation">
+        <Tooltip title="Abort current operation" placement="bottom">
           <Button onClick={() => abortCurrentPlan()}>Abort!</Button>
         </Tooltip>
       </Stack>
@@ -140,7 +140,10 @@ function CollectionInput() {
         <FixedInputs />
         <Grid2 size={4.5}>
           <Stack direction={"column"} spacing={1} alignItems={"center"}>
-            <Tooltip title="Location inside visit directory to save data">
+            <Tooltip
+              title="Location inside visit directory to save data"
+              placement="right"
+            >
               <TextField
                 size="small"
                 label="Sub-directory"
@@ -149,7 +152,10 @@ function CollectionInput() {
                 style={{ width: 180 }}
               />
             </Tooltip>
-            <Tooltip title="Chip identifier, this will be used as filename">
+            <Tooltip
+              title="Chip identifier, this will be used as filename"
+              placement="right"
+            >
               <TextField
                 size="small"
                 label="Chip Name"
@@ -158,7 +164,10 @@ function CollectionInput() {
                 style={{ width: 180 }}
               />
             </Tooltip>
-            <Tooltip title="How many consecutive times each window should be collected.">
+            <Tooltip
+              title="How many consecutive times each window should be collected."
+              placement="right"
+            >
               <TextField
                 size="small"
                 label="Shots Per Aperture"
@@ -167,7 +176,10 @@ function CollectionInput() {
                 style={{ width: 180 }}
               />
             </Tooltip>
-            <Tooltip title="Exposure time for each window, in seconds">
+            <Tooltip
+              title="Exposure time for each window, in seconds"
+              placement="right"
+            >
               <TextField
                 size="small"
                 label="Exposure Time (s)"
@@ -176,7 +188,10 @@ function CollectionInput() {
                 style={{ width: 180 }}
               />
             </Tooltip>
-            <Tooltip title="Request transmission for collection, expressed as a fraction">
+            <Tooltip
+              title="Request transmission for collection, expressed as a fraction"
+              placement="right"
+            >
               <TextField
                 size="small"
                 label="Transmission (fraction)"
@@ -185,7 +200,10 @@ function CollectionInput() {
                 style={{ width: 180 }}
               />
             </Tooltip>
-            <Tooltip title="Distance to move the detector y stage to, in millimeters">
+            <Tooltip
+              title="Distance to move the detector y stage to, in millimeters"
+              placement="right"
+            >
               <TextField
                 size="small"
                 label="Detector Distance (mm)"
@@ -199,7 +217,7 @@ function CollectionInput() {
         {/* See https://github.com/DiamondLightSource/mx-daq-ui/issues/25 */}
         <Grid2 size={3}>
           <Stack spacing={1} direction={"column"}>
-            <Tooltip title="Select for drop on chip">
+            <Tooltip title="Select for drop on chip" placement="right">
               <FormControl>
                 <FormControlLabel
                   label="Checker Pattern"
@@ -212,7 +230,10 @@ function CollectionInput() {
                 />
               </FormControl>
             </Tooltip>
-            <Tooltip title="Is this a pump probe experiment? Choose the setting.">
+            <Tooltip
+              title="Is this a pump probe experiment? Choose the setting."
+              placement="right"
+            >
               <FormControl size="small" style={{ width: 150 }}>
                 <InputLabel id="pp-label">Pump Probe</InputLabel>
                 <Select
@@ -242,7 +263,7 @@ function CollectionInput() {
         </Grid2>
         <Grid2 size={4.5}>
           <Stack direction={"column"} alignItems={"center"} spacing={1}>
-            <Tooltip title="Select the type of chip in use">
+            <Tooltip title="Select the type of chip in use" placement="right">
               <FormControl size="small" style={{ width: 150 }}>
                 <InputLabel id="chip-label">Chip Type</InputLabel>
                 <Select

--- a/src/screens/CollectionPanel.tsx
+++ b/src/screens/CollectionPanel.tsx
@@ -197,7 +197,7 @@ function CollectionInput() {
               </Select>
             </FormControl>
             {/* See https://github.com/DiamondLightSource/mx-daq-ui/issues/3?issue=DiamondLightSource%7Cmx-daq-ui%7C5 */}
-            <MapView label="map" chipType={chipType} />
+            <MapView chipType={chipType} />
           </Stack>
         </Grid2>
       </Grid2>

--- a/src/screens/CollectionPanel.tsx
+++ b/src/screens/CollectionPanel.tsx
@@ -13,7 +13,7 @@ import {
 } from "@mui/material";
 import { PvComponent, PvItem } from "../pv/PvComponent";
 import React from "react";
-import { PumpProbeDialog } from "../components/CollectionComponents";
+import { MapView, PumpProbeDialog } from "../components/CollectionComponents";
 import {
   abortCurrentPlan,
   submitAndRunPlanImmediately,
@@ -197,7 +197,7 @@ function CollectionInput() {
               </Select>
             </FormControl>
             {/* See https://github.com/DiamondLightSource/mx-daq-ui/issues/3?issue=DiamondLightSource%7Cmx-daq-ui%7C5 */}
-            <p>Chip-dependent Map settings TBD.</p>
+            <MapView label="map" chipType={chipType} />
           </Stack>
         </Grid2>
       </Grid2>

--- a/src/screens/CollectionPanel.tsx
+++ b/src/screens/CollectionPanel.tsx
@@ -82,7 +82,7 @@ type ParametersProp = {
 function RunButtons(props: ParametersProp) {
   return (
     <Grid2 size={12}>
-      <Stack direction={"row"} spacing={10} justifyContent={"center"}>
+      <Stack direction={"row"} spacing={8} justifyContent={"center"}>
         {/* See
           https://github.com/DiamondLightSource/mx-daq-ui/issues/3?issue=DiamondLightSource%7Cmx-daq-ui%7C18 */}
         <Button

--- a/src/screens/CollectionPanel.tsx
+++ b/src/screens/CollectionPanel.tsx
@@ -85,6 +85,7 @@ type ParametersProp = {
 };
 
 function RunButtons(props: ParametersProp) {
+  console.log(props);
   return (
     <Grid2 size={12}>
       <Stack direction={"row"} spacing={8} justifyContent={"center"}>

--- a/src/screens/TestBoxes.tsx
+++ b/src/screens/TestBoxes.tsx
@@ -31,7 +31,7 @@ export function TestBoxesTabPanel() {
               return (
                 <Box>
                   <p>
-                    <b>{label}:</b> {parseNumericPv(value)}
+                    <b>{label}:</b> {parseNumericPv(value, 4)}
                   </p>
                 </Box>
               );


### PR DESCRIPTION
Closes #5 

- Adds a first version of choice for chip type and map
- Tidies up a couple of components

(#28 should be merged first)

Takes care of most of #18 , which will need the plan on the mx-bluesky side to actually run the collection.

Needs [mx-bluesky#907](https://github.com/DiamondLightSource/mx-bluesky/pull/907)