### PR TITLE
Add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @DiamondLightSource/developers-mx-daq


### PR DESCRIPTION
Adds codeowners so that everyone is automatically added as a reviewer. I don't think we can actually see this working until we merge it main.

### Instructions to reviewer on how to test:

1. Confirm it looks like https://github.com/orgs/DiamondLightSource/teams/developers-mx-daq will be added as reviewers automatically (compare to dodal setup?)
2. Confirm that https://github.com/orgs/DiamondLightSource/teams/developers-mx-daq has the right members

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
