### PR TITLE
Added preset buttons

### DIFF
--- a/src/screens/OavMover.tsx
+++ b/src/screens/OavMover.tsx
@@ -249,7 +249,7 @@ export function SideDrawer() {
   return (
     <>
       <Button style={buttonStyle} onClick={toggleDrawer(true)}>
-        Open drawer
+        Preset Positions
       </Button>
       <Drawer open={open} onClose={toggleDrawer(false)}>
         <PresetMovements />


### PR DESCRIPTION
For Issue: #12 
Added the three preset buttons for blueapi. Doesn't take up too much space on the screen so not sure if it's really worth creating a temporary drawer for it. Wouldn't it be easier to set a variable to hide the preset buttons on beamlines that don't use it instead of a drawer?