### PR TITLE
57 scrollable oav view controls

### DIFF
--- a/src/screens/OavMover.tsx
+++ b/src/screens/OavMover.tsx
@@ -446,7 +446,7 @@ export function OavMover() {
         <Grid2
           size={3}
           sx={{
-            height: "95vh",
+            height: "95vh", // Height set to 95vh to span height of screen but to also leave 5vh space for the top navigation header.
             overflowY: "auto",
             padding: 2,
             boxSizing: "border-box",


### PR DESCRIPTION
Fixes #57 
Turns the column next to the OAV View to a scrollable column. Currently it is set to be 95VH so it's always the size of the viewable screen instead of matching the size of the viewer.