### PR TITLE
Have alerts/snackbars show up in case of issues running blueapi

### DIFF
--- a/src/blueapi/BlueapiComponents.tsx
+++ b/src/blueapi/BlueapiComponents.tsx
@@ -9,20 +9,52 @@ import {
   Typography,
 } from "@mui/material";
 
+type SeverityLevel = "success" | "info" | "warning" | "error";
 type VariantChoice = "outlined" | "contained";
+type ButtonSize = "small" | "medium" | "large";
 
-type PlanButtonProps = {
+type RunPlanButtonProps = {
   btnLabel: string;
   planName: string;
   planParams?: object;
   title?: string;
-  //   btnColour?: string;
   btnVariant?: VariantChoice;
+  btnSize?: ButtonSize;
 };
 
-export function RunPlanButton(props: PlanButtonProps) {
+export function RunPlanButton(props: RunPlanButtonProps) {
+  const [openSnackbar, setOpenSnackbar] = React.useState<boolean>(false);
+  const [msg, setMsg] = React.useState<string>("Running plan...");
+  const [severity, setSeverity] = React.useState<SeverityLevel>("info");
+
   const params = props.planParams ? props.planParams : {};
   const variant = props.btnVariant ? props.btnVariant : "outlined";
+  const size = props.btnSize ? props.btnSize : "medium";
+
+  const handleClick = () => {
+    setOpenSnackbar(true);
+    submitAndRunPlanImmediately({
+      planName: props.planName,
+      planParams: params,
+    }).catch((error) => {
+      setSeverity("error");
+      setMsg(
+        `Failed to run plan ${props.planName}, see console and logs for full error`
+      );
+      console.log(`${msg}. Reason: ${error}`);
+    });
+  };
+
+  const handleSnackbarClose = (
+    _event: React.SyntheticEvent | Event,
+    reason?: SnackbarCloseReason
+  ) => {
+    if (reason === "clickaway") {
+      return;
+    }
+
+    setOpenSnackbar(false);
+  };
 
   return (
     <div>
@@ -30,16 +62,28 @@ export function RunPlanButton(props: PlanButtonProps) {
         <Button
           variant={variant}
           color="custom"
-          onClick={() =>
-            submitAndRunPlanImmediately({
-              planName: props.planName,
-              planParams: params,
-            })
-          }
+          size={size}
+          onClick={handleClick}
         >
-          {props.btnLabel}
+          <Typography
+            variant="button"
+            fontWeight="fontWeightBold"
+            sx={{ display: "block" }}
+          >
+            {props.btnLabel}
+          </Typography>
         </Button>
       </Tooltip>
+      <Snackbar
+        open={openSnackbar}
+        autoHideDuration={5000}
+        onClose={handleSnackbarClose}
+        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+      >
+        <Alert onClose={handleSnackbarClose} severity={severity}>
+          {msg}
+        </Alert>
+      </Snackbar>
     </div>
   );
 }

--- a/src/blueapi/BlueapiComponents.tsx
+++ b/src/blueapi/BlueapiComponents.tsx
@@ -8,6 +8,8 @@ import {
   Tooltip,
 } from "@mui/material";
 
+export function RunPlanButton() {}
+
 export function AbortButton() {
   const [openMsg, setOpenMsg] = React.useState<boolean>(false);
 

--- a/src/blueapi/BlueapiComponents.tsx
+++ b/src/blueapi/BlueapiComponents.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { abortCurrentPlan } from "./blueapi";
+import { abortCurrentPlan, submitAndRunPlanImmediately } from "./blueapi";
 import {
   Alert,
   Button,
@@ -8,7 +8,37 @@ import {
   Tooltip,
 } from "@mui/material";
 
-export function RunPlanButton() {}
+type PlanButtonProps = {
+  btnLabel: string;
+  planName: string;
+  planParams?: object;
+  title?: string;
+  //   btnColour?: string;
+  //   btnVariant?: string;
+};
+
+export function RunPlanButton(props: PlanButtonProps) {
+  const params = props.planParams ? props.planParams : {};
+
+  return (
+    <div>
+      <Tooltip title={props.title ? props.title : ""} placement="bottom">
+        <Button
+          variant="contained"
+          color="custom"
+          onClick={() =>
+            submitAndRunPlanImmediately({
+              planName: props.planName,
+              planParams: params,
+            })
+          }
+        >
+          {props.btnLabel}
+        </Button>
+      </Tooltip>
+    </div>
+  );
+}
 
 export function AbortButton() {
   const [openMsg, setOpenMsg] = React.useState<boolean>(false);

--- a/src/blueapi/BlueapiComponents.tsx
+++ b/src/blueapi/BlueapiComponents.tsx
@@ -5,6 +5,7 @@ import {
   Button,
   Snackbar,
   SnackbarCloseReason,
+  styled,
   Tooltip,
   Typography,
 } from "@mui/material";
@@ -21,6 +22,15 @@ type RunPlanButtonProps = {
   btnVariant?: VariantChoice;
   btnSize?: ButtonSize;
 };
+
+// const CustomRunButton = styled(Button)({
+//   width: "100%",
+//   height: "85%",
+//   color: "var(--color)",
+//   backgroundColor: "var(--backgroundColor)",
+//   padding: "var(--padding)",
+//   margin: "var(--margin)",
+// });
 
 export function RunPlanButton(props: RunPlanButtonProps) {
   const [openSnackbar, setOpenSnackbar] = React.useState<boolean>(false);

--- a/src/blueapi/BlueapiComponents.tsx
+++ b/src/blueapi/BlueapiComponents.tsx
@@ -23,6 +23,8 @@ type RunPlanButtonProps = {
   btnSize?: ButtonSize;
 };
 
+// @{todo} Ideally we should be able to set up the stylings for
+// a custom button in the proper way by doing something like:
 // const CustomRunButton = styled(Button)({
 //   width: "100%",
 //   height: "85%",
@@ -31,6 +33,7 @@ type RunPlanButtonProps = {
 //   padding: "var(--padding)",
 //   margin: "var(--margin)",
 // });
+// This will be another PR (link to come)
 
 export function RunPlanButton(props: RunPlanButtonProps) {
   const [openSnackbar, setOpenSnackbar] = React.useState<boolean>(false);

--- a/src/blueapi/BlueapiComponents.tsx
+++ b/src/blueapi/BlueapiComponents.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { abortCurrentPlan } from "./blueapi";
+import {
+  Alert,
+  Button,
+  Snackbar,
+  SnackbarCloseReason,
+  Tooltip,
+} from "@mui/material";
+
+export function AbortButton() {
+  const [openMsg, setOpenMsg] = React.useState<boolean>(false);
+
+  const handleClick = () => {
+    setOpenMsg(true);
+    abortCurrentPlan();
+  };
+
+  const handleMsgClose = (
+    _event: React.SyntheticEvent | Event,
+    reason?: SnackbarCloseReason
+  ) => {
+    if (reason === "clickaway") {
+      return;
+    }
+
+    setOpenMsg(false);
+  };
+
+  return (
+    <div>
+      <Tooltip title="Abort current blueapi operation" placement="bottom">
+        <Button color="custom" variant="outlined" onClick={handleClick}>
+          Abort!
+        </Button>
+      </Tooltip>
+      <Snackbar
+        open={openMsg}
+        autoHideDuration={5000}
+        onClose={handleMsgClose}
+        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+      >
+        <Alert onClose={handleMsgClose} severity="warning">
+          Aborting plan ...
+        </Alert>
+      </Snackbar>
+    </div>
+  );
+}

--- a/src/blueapi/BlueapiComponents.tsx
+++ b/src/blueapi/BlueapiComponents.tsx
@@ -33,7 +33,8 @@ type RunPlanButtonProps = {
 //   padding: "var(--padding)",
 //   margin: "var(--margin)",
 // });
-// This will be another PR (link to come)
+// This will be another PR
+// See https://github.com/DiamondLightSource/mx-daq-ui/issues/71
 
 export function RunPlanButton(props: RunPlanButtonProps) {
   const [openSnackbar, setOpenSnackbar] = React.useState<boolean>(false);

--- a/src/blueapi/BlueapiComponents.tsx
+++ b/src/blueapi/BlueapiComponents.tsx
@@ -8,23 +8,26 @@ import {
   Tooltip,
 } from "@mui/material";
 
+type VariantChoice = "outlined" | "contained";
+
 type PlanButtonProps = {
   btnLabel: string;
   planName: string;
   planParams?: object;
   title?: string;
   //   btnColour?: string;
-  //   btnVariant?: string;
+  btnVariant?: VariantChoice;
 };
 
 export function RunPlanButton(props: PlanButtonProps) {
   const params = props.planParams ? props.planParams : {};
+  const variant = props.btnVariant ? props.btnVariant : "outlined";
 
   return (
     <div>
       <Tooltip title={props.title ? props.title : ""} placement="bottom">
         <Button
-          variant="contained"
+          variant={variant}
           color="custom"
           onClick={() =>
             submitAndRunPlanImmediately({

--- a/src/blueapi/blueapi.ts
+++ b/src/blueapi/blueapi.ts
@@ -102,13 +102,11 @@ function runTask(taskId: string): Promise<string | void> {
 export function submitAndRunPlanImmediately(
   request: BlueApiRequestBody
 ): Promise<string | void> {
-  return submitTask(request)
-    .then((res) => {
-      if (res) {
-        runTask(res);
-      }
-    })
-    .catch((error) => console.log(`NOPE ${error}`));
+  return submitTask(request).then((res) => {
+    if (res) {
+      runTask(res);
+    }
+  });
 }
 
 export function abortCurrentPlan(): Promise<BlueApiWorkerState> {

--- a/src/blueapi/blueapi.ts
+++ b/src/blueapi/blueapi.ts
@@ -5,6 +5,7 @@ const BLUEAPI_SOCKET: string = import.meta.env.VITE_BLUEAPI_SOCKET;
 type BlueApiRequestBody = {
   planName: string;
   planParams: object;
+  // instrumentSession: string;
 };
 // @todo check if blueapi request still works if planParams optional (since some times there's none)
 

--- a/src/blueapi/blueapi.ts
+++ b/src/blueapi/blueapi.ts
@@ -44,13 +44,12 @@ export function useBlueApiCall(
   pollRateMillis?: number,
   queryKey?: string
 ) {
-  return useQuery(
-    queryKey ?? "BlueApiCall",
-    async () => await blueApiCall(endpoint, method, body),
-    {
-      refetchInterval: pollRateMillis ?? 500,
-    }
-  );
+  const fetchCall = async () => {
+    return await blueApiCall(endpoint, method, body);
+  };
+  return useQuery(queryKey ?? "BlueApiCall", fetchCall, {
+    refetchInterval: pollRateMillis ?? 500,
+  });
 }
 
 export function processUseBlueApiCall(

--- a/src/blueapi/blueapi.ts
+++ b/src/blueapi/blueapi.ts
@@ -80,7 +80,7 @@ function submitTask(request: BlueApiRequestBody): Promise<string | void> {
   }).then((res) => {
     if (!res.ok) {
       throw new Error(
-        `Unable to POST request, response error ${res.statusText}`
+        `Unable to POST request, response error ${res.status} ${res.statusText}`
       );
     }
     res.json().then((res) => res["task_id"]);
@@ -90,7 +90,9 @@ function submitTask(request: BlueApiRequestBody): Promise<string | void> {
 function runTask(taskId: string): Promise<string | void> {
   return blueApiCall("/worker/task", "PUT", { task_id: taskId }).then((res) => {
     if (!res.ok) {
-      throw new Error(`Unable to run task, response error ${res.statusText}`);
+      throw new Error(
+        `Unable to run task, response error ${res.status} ${res.statusText}`
+      );
     }
     res.json().then((res) => res["task_id"]);
   });
@@ -105,7 +107,7 @@ export function submitAndRunPlanImmediately(
         runTask(res);
       }
     })
-    .catch((error) => console.log(error));
+    .catch((error) => console.log(`NOPE ${error}`));
 }
 
 export function abortCurrentPlan(): Promise<BlueApiWorkerState> {

--- a/src/blueapi/blueapi.ts
+++ b/src/blueapi/blueapi.ts
@@ -7,6 +7,7 @@ type BlueApiRequestBody = {
   planParams: object;
   // instrumentSession: string;
 };
+// Update to latest blueapi (> 1.0.0), See https://github.com/DiamondLightSource/mx-daq-ui/issues/72
 // @todo check if blueapi request still works if planParams optional (since some times there's none)
 
 export type BlueApiWorkerState =

--- a/src/components/WorkerStatus.tsx
+++ b/src/components/WorkerStatus.tsx
@@ -1,4 +1,4 @@
-import { Box, Grid2, Stack } from "@mui/material";
+import { Grid2, Stack, Typography } from "@mui/material";
 
 import { processUseBlueApiCall, useBlueApiCall } from "../blueapi/blueapi";
 import { useState } from "react";
@@ -6,18 +6,23 @@ import { useState } from "react";
 export function WorkerStatus() {
   const [currentState, setCurrentState] = useState<string>("UNKNOWN");
   const workerStateInfo = useBlueApiCall("/worker/state");
+
+  const readCurrentState = () => {
+    return processUseBlueApiCall(workerStateInfo, (res) => {
+      if (!res.bodyUsed) {
+        res.json().then((text) => setCurrentState(text));
+      }
+      return currentState;
+    });
+  };
+
   return (
     <Grid2 size={12}>
       <Stack direction={"row"} spacing={1} justifyContent={"center"}>
-        <b>BlueAPI worker status: </b>
-        <Box>
-          {processUseBlueApiCall(workerStateInfo, (res) => {
-            if (!res.bodyUsed) {
-              res.json().then((text) => setCurrentState(text));
-            }
-            return currentState;
-          })}
-        </Box>
+        <Typography variant="body1" fontWeight={"bold"}>
+          BlueAPI worker status:
+        </Typography>
+        <Typography variant="body1">{readCurrentState()}</Typography>
       </Stack>
     </Grid2>
   );

--- a/src/screens/CollectionPanel.tsx
+++ b/src/screens/CollectionPanel.tsx
@@ -19,6 +19,7 @@ import {
 } from "../blueapi/blueapi";
 import { chipTypes, MapTypes, pumpProbeMode } from "../components/params";
 import { forceString } from "../pv/util";
+import { AbortButton } from "../blueapi/BlueapiComponents";
 
 /**
  * A couple of read-only boxes showing what the visit and detector in use are.
@@ -96,15 +97,7 @@ function RunButtons(props: ParametersProps) {
             Start!
           </Button>
         </Tooltip>
-        <Tooltip title="Abort current operation" placement="bottom">
-          <Button
-            color="custom"
-            variant="outlined"
-            onClick={() => abortCurrentPlan()}
-          >
-            Abort!
-          </Button>
-        </Tooltip>
+        <AbortButton />
       </Stack>
     </Grid2>
   );

--- a/src/screens/CollectionPanel.tsx
+++ b/src/screens/CollectionPanel.tsx
@@ -13,10 +13,7 @@ import {
 import { PvComponent } from "../pv/PvComponent";
 import React from "react";
 import { MapView, PumpProbeOptions } from "../components/CollectionComponents";
-import {
-  abortCurrentPlan,
-  submitAndRunPlanImmediately,
-} from "../blueapi/blueapi";
+import { submitAndRunPlanImmediately } from "../blueapi/blueapi";
 import { chipTypes, MapTypes, pumpProbeMode } from "../components/params";
 import { forceString } from "../pv/util";
 import { AbortButton } from "../blueapi/BlueapiComponents";

--- a/src/screens/CollectionPanel.tsx
+++ b/src/screens/CollectionPanel.tsx
@@ -17,7 +17,7 @@ import { MapView, PumpProbeOptions } from "../components/CollectionComponents";
 import { submitAndRunPlanImmediately } from "../blueapi/blueapi";
 import { chipTypes, MapTypes, pumpProbeMode } from "../components/params";
 import { forceString } from "../pv/util";
-import { AbortButton } from "../blueapi/BlueapiComponents";
+import { AbortButton, RunPlanButton } from "../blueapi/BlueapiComponents";
 
 /**
  * A couple of read-only boxes showing what the visit and detector in use are.
@@ -64,44 +64,28 @@ function RunButtons(props: ParametersProps) {
   return (
     <Grid2 size={12}>
       <Stack direction={"row"} spacing={8} justifyContent={"center"}>
-        {/* See
-          https://github.com/DiamondLightSource/mx-daq-ui/issues/3?issue=DiamondLightSource%7Cmx-daq-ui%7C18 */}
-        <Tooltip title="Start fixed target collection" placement="bottom">
-          <Button
-            variant="outlined"
-            color="custom"
-            size="large"
-            onClick={() =>
-              submitAndRunPlanImmediately({
-                planName: "gui_run_chip_collection",
-                planParams: {
-                  sub_dir: props.subDir,
-                  chip_name: props.chipName,
-                  exp_time: props.expTime,
-                  det_dist: props.detDist,
-                  transmission: props.transFract,
-                  n_shots: props.nShots,
-                  chip_type: props.chipType,
-                  map_type: props.mapType,
-                  chip_format: props.chipFormat,
-                  checker_pattern: props.checkerPattern,
-                  pump_probe: props.pumpProbe,
-                  laser_dwell: props.pumpInputs[0],
-                  laser_delay: props.pumpInputs[1],
-                  pre_pump: props.pumpInputs[2],
-                },
-              })
-            }
-          >
-            <Typography
-              variant="button"
-              fontWeight="fontWeightBold"
-              sx={{ display: "block" }}
-            >
-              Start!
-            </Typography>
-          </Button>
-        </Tooltip>
+        <RunPlanButton
+          btnLabel="Start!"
+          planName="gui_run_chip_collection"
+          planParams={{
+            sub_dir: props.subDir,
+            chip_name: props.chipName,
+            exp_time: props.expTime,
+            det_dist: props.detDist,
+            transmission: props.transFract,
+            n_shots: props.nShots,
+            chip_type: props.chipType,
+            map_type: props.mapType,
+            chip_format: props.chipFormat,
+            checker_pattern: props.checkerPattern,
+            pump_probe: props.pumpProbe,
+            laser_dwell: props.pumpInputs[0],
+            laser_delay: props.pumpInputs[1],
+            pre_pump: props.pumpInputs[2],
+          }}
+          title="Start fixed target collection"
+          btnSize="large"
+        />
         <AbortButton />
       </Stack>
     </Grid2>

--- a/src/screens/CollectionPanel.tsx
+++ b/src/screens/CollectionPanel.tsx
@@ -1,6 +1,5 @@
 import {
   Box,
-  Button,
   FormControl,
   Grid2,
   InputLabel,
@@ -9,12 +8,10 @@ import {
   Stack,
   TextField,
   Tooltip,
-  Typography,
 } from "@mui/material";
 import { PvComponent } from "../pv/PvComponent";
 import React from "react";
 import { MapView, PumpProbeOptions } from "../components/CollectionComponents";
-import { submitAndRunPlanImmediately } from "../blueapi/blueapi";
 import { chipTypes, MapTypes, pumpProbeMode } from "../components/params";
 import { forceString } from "../pv/util";
 import { AbortButton, RunPlanButton } from "../blueapi/BlueapiComponents";

--- a/src/screens/DetectorMotion.tsx
+++ b/src/screens/DetectorMotion.tsx
@@ -1,6 +1,7 @@
 import { Button, Stack, Box, useTheme } from "@mui/material";
 import { RoPvBox } from "../pv/PvComponent";
 import { submitAndRunPlanImmediately } from "../blueapi/blueapi";
+import { RunPlanButton } from "../blueapi/BlueapiComponents";
 
 function DetectorState() {
   const theme = useTheme();
@@ -29,32 +30,20 @@ export function DetectorMotionTabPanel() {
           pv="ca://BL24I-EA-DET-01:Z"
         />
         <Stack direction={"row"} spacing={5} justifyContent={"center"}>
-          <Button
-            color="custom"
-            variant="contained"
-            onClick={() =>
-              submitAndRunPlanImmediately({
-                planName: "gui_move_detector",
-                planParams: { det: "eiger" },
-              })
-            }
-          >
-            Move to Eiger!
-          </Button>
-          <Button
-            color="custom"
-            variant="contained"
-            onClick={() =>
-              submitAndRunPlanImmediately({
-                planName: "gui_move_detector",
-                planParams: {
-                  det: "pilatus",
-                },
-              })
-            }
-          >
-            Move to Pilatus!
-          </Button>
+          <RunPlanButton
+            btnLabel="Move to Eiger!"
+            planName="gui_move_detector"
+            planParams={{ det: "eiger" }}
+            title="Move the detector stage for Eiger collection"
+            btnVariant="contained"
+          />
+          <RunPlanButton
+            btnLabel="Move to Pilatus!"
+            planName="gui_move_detector"
+            planParams={{ det: "pilatus" }}
+            title="Move the detector stage for Pilatus collection"
+            btnVariant="contained"
+          />
         </Stack>
         <DetectorState />
       </Stack>

--- a/src/screens/DetectorMotion.tsx
+++ b/src/screens/DetectorMotion.tsx
@@ -1,6 +1,5 @@
-import { Button, Stack, Box, useTheme } from "@mui/material";
+import { Stack, Box, useTheme } from "@mui/material";
 import { RoPvBox } from "../pv/PvComponent";
-import { submitAndRunPlanImmediately } from "../blueapi/blueapi";
 import { RunPlanButton } from "../blueapi/BlueapiComponents";
 
 function DetectorState() {

--- a/src/screens/OavMover.tsx
+++ b/src/screens/OavMover.tsx
@@ -21,6 +21,7 @@ import {
   ArrowUpwardRounded,
   Close,
   Help,
+  Padding,
 } from "@mui/icons-material";
 import { useState } from "react";
 
@@ -31,6 +32,7 @@ import { PvDescription } from "../pv/types";
 import { SelectionWithPlanRunner } from "../components/SelectionControl";
 import { BacklightPositions, ZoomLevels } from "../pv/enumPvValues";
 import oxfordChipDiagram from "../assets/Oxford Chip Diagram.excalidraw.svg";
+import { RunPlanButton } from "../blueapi/BlueapiComponents";
 
 const buttonStyle = {
   color: "white",
@@ -205,59 +207,34 @@ export function PresetMovements() {
       <p>
         <b>Preset Positions</b>
       </p>
-      <Grid2>
-        <Tooltip title={"Move into position for collection"}>
-          <Button
-            style={buttonStyle}
-            onClick={() =>
-              submitAndRunPlanImmediately({
-                planName: "moveto_preset",
-                planParams: {
-                  place: "collect_position",
-                },
-              })
-            }
-          >
-            Collect Position
-          </Button>
-        </Tooltip>
-
-        <Tooltip title={"Move hardware for sample loading"}>
-          <Button
-            style={buttonStyle}
-            onClick={() =>
-              submitAndRunPlanImmediately({
-                planName: "moveto_preset",
-                planParams: {
-                  place: "load_position",
-                },
-              })
-            }
-          >
-            Load Position
-          </Button>
-        </Tooltip>
-        <Tooltip title={"Align microdrop"}>
-          <Button
-            style={buttonStyle}
-            onClick={() =>
-              submitAndRunPlanImmediately({
-                planName: "moveto_preset",
-                planParams: {
-                  place: "microdrop_position",
-                },
-              })
-            }
-          >
-            Microdrop Align
-          </Button>
-        </Tooltip>
-      </Grid2>
+      <Stack padding={"20px"} margin={"10px"} spacing={1}>
+        <RunPlanButton
+          btnLabel="Collect Position"
+          planName="moveto_preset"
+          planParams={{ place: "collect_position" }}
+          title="Move into position for collection"
+          btnSize="small"
+        />
+        <RunPlanButton
+          btnLabel="Load Position"
+          planName="moveto_preset"
+          planParams={{ place: "load_position" }}
+          title="Move hardware for sample loading"
+          btnSize="small"
+        />
+        <RunPlanButton
+          btnLabel="Microdrop align"
+          planName="moveto_preset"
+          planParams={{ place: "microdrop_position" }}
+          title="Align microdrop"
+          btnSize="small"
+        />
+      </Stack>
     </Box>
   );
 }
 
-export function SideDrawer() {
+export function PresetPositionsSideDrawer() {
   const [open, setOpen] = useState(false);
   const toggleDrawer = (newOpen: boolean) => () => {
     setOpen(newOpen);
@@ -507,7 +484,7 @@ export function OavMover() {
           <hr />
           <CoordinateSystem />
           <hr />
-          <SideDrawer />
+          <PresetPositionsSideDrawer />
         </Grid2>
       </Grid2>
     </div>

--- a/src/screens/OavMover.tsx
+++ b/src/screens/OavMover.tsx
@@ -285,6 +285,7 @@ export function CoordinateSystem() {
               planParams={{ place: "zero" }}
               title="Go to Fiducial 0"
               btnVariant="contained"
+              btnSize="large"
             />
           </Grid2>
           <Grid2 size={4}>
@@ -294,6 +295,7 @@ export function CoordinateSystem() {
               planParams={{ place: "f1" }}
               title="Go to Fiducial 1"
               btnVariant="contained"
+              btnSize="large"
             />
           </Grid2>
           <Grid2 size={4}>
@@ -303,6 +305,7 @@ export function CoordinateSystem() {
               planParams={{ place: "f2" }}
               title="Go to Fiducial 2"
               btnVariant="contained"
+              btnSize="large"
             />
           </Grid2>
           <Grid2 size={4}>

--- a/src/screens/OavMover.tsx
+++ b/src/screens/OavMover.tsx
@@ -273,7 +273,7 @@ export function CoordinateSystem() {
   return (
     <>
       <Box>
-        <Grid2 container rowSpacing={0} spacing={1}>
+        <Grid2 container alignItems={"center"} rowSpacing={1} spacing={0.5}>
           <Grid2 size={10}>
             <b>Co-ordinate System Setup</b>
           </Grid2>
@@ -281,108 +281,73 @@ export function CoordinateSystem() {
             <Help onClick={handleClickOpen} />
           </Grid2>
           <Grid2 size={4}>
-            <Button
-              style={buttonStyle}
-              onClick={() =>
-                submitAndRunPlanImmediately({
-                  planName: "moveto",
-                  planParams: {
-                    place: "zero",
-                  },
-                })
-              }
-            >
-              Go to Origin
-            </Button>
+            <RunPlanButton
+              btnLabel="Go to origin"
+              planName="moveto"
+              planParams={{ place: "zero" }}
+              title="Go to Fiducial 0"
+              btnVariant="contained"
+            />
           </Grid2>
           <Grid2 size={4}>
-            <Button
-              style={buttonStyle}
-              onClick={() =>
-                submitAndRunPlanImmediately({
-                  planName: "moveto",
-                  planParams: {
-                    place: "f1",
-                  },
-                })
-              }
-            >
-              Go to Fiducial 1
-            </Button>
+            <RunPlanButton
+              btnLabel="Go to Fiducial1"
+              planName="moveto"
+              planParams={{ place: "f1" }}
+              title="Go to Fiducial 1"
+              btnVariant="contained"
+            />
           </Grid2>
           <Grid2 size={4}>
-            <Button
-              style={buttonStyle}
-              onClick={() =>
-                submitAndRunPlanImmediately({
-                  planName: "moveto",
-                  planParams: {
-                    place: "f2",
-                  },
-                })
-              }
-            >
-              Go to Fiducial 2
-            </Button>
+            <RunPlanButton
+              btnLabel="Go to Fiducial2"
+              planName="moveto"
+              planParams={{ place: "f2" }}
+              title="Go to Fiducial 2"
+              btnVariant="contained"
+            />
           </Grid2>
           <Grid2 size={4}>
-            <Button style={buttonStyle}>Set Fiducial 0</Button>
+            <RunPlanButton
+              btnLabel="Set Fiducial0"
+              planName="gui_set_fiducial_0"
+              title="Set Fiducial 0"
+              btnVariant="contained"
+            />
           </Grid2>
           <Grid2 size={4}>
-            <Button
-              style={buttonStyle}
-              onClick={() =>
-                submitAndRunPlanImmediately({
-                  planName: "fiducial",
-                  planParams: {
-                    point: "1",
-                  },
-                })
-              }
-            >
-              Set Fiducial 1
-            </Button>
+            <RunPlanButton
+              btnLabel="Set Fiducial1"
+              planName="fiducial"
+              planParams={{ point: "1" }}
+              title="Set Fiducial 1"
+              btnVariant="contained"
+            />
           </Grid2>
           <Grid2 size={4}>
-            <Button
-              style={buttonStyle}
-              onClick={() =>
-                submitAndRunPlanImmediately({
-                  planName: "fiducial",
-                  planParams: {
-                    point: "2",
-                  },
-                })
-              }
-            >
-              Set Fiducial 2
-            </Button>
+            <RunPlanButton
+              btnLabel="Set Fiducial2"
+              planName="fiducial"
+              planParams={{ point: "2" }}
+              title="Set Fiducial 2"
+              btnVariant="contained"
+            />
           </Grid2>
           <Grid2 size={6}>
-            <Button
-              style={buttonStyle}
-              onClick={() =>
-                submitAndRunPlanImmediately({
-                  planName: "cs_maker",
-                  planParams: {},
-                })
-              }
-            >
-              Make Coordinate System
-            </Button>
+            <RunPlanButton
+              btnLabel="Make Coord System"
+              planName="cs_maker"
+              title="Create the coordinate system on the pmac."
+              btnVariant="contained"
+            />
           </Grid2>
           <Grid2 size={6}>
-            <Button
-              style={buttonStyle}
-              onClick={() =>
-                submitAndRunPlanImmediately({
-                  planName: "block_check",
-                  planParams: {},
-                })
-              }
-            >
-              Block Check
-            </Button>
+            <RunPlanButton
+              btnLabel="Run block check"
+              planName="block_check"
+              title="Check the coordinate system was set up correctly."
+              btnVariant="contained"
+            />
           </Grid2>
         </Grid2>
       </Box>

--- a/src/screens/OavMover.tsx
+++ b/src/screens/OavMover.tsx
@@ -11,7 +11,6 @@ import {
   Typography,
   useTheme,
   Drawer,
-  Tooltip,
 } from "@mui/material";
 import { OavVideoStream } from "../components/OavVideoStream";
 import {
@@ -21,7 +20,6 @@ import {
   ArrowUpwardRounded,
   Close,
   Help,
-  Padding,
 } from "@mui/icons-material";
 import { useState } from "react";
 


### PR DESCRIPTION
- Adds a custom button for aborting pleans in blueapi which will bring up an alert in a snackbar
- Adds a custom button to run bluesky plans which can catch errors and bring up an alert in a snackbar if something went wrong with the plan. If the plan works, for the moment it will only bring up an info snackbar indicating that it has started

Closes #61 

Spawned #71 #72 and #73