### PR TITLE
Added node 24

### DIFF
--- a/.github/workflows/_tests.yaml
+++ b/.github/workflows/_tests.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [22]
+        node-version: [22, 24]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
Fixes #104 

Node 26 will come out in April 2026 so will require updating again eventually to cover 22, 24 and 26.