### PR TITLE
Use text.primary for Jungfrau panel headings

### DIFF
--- a/src/components/JungFrau/CollectDarksPanel.tsx
+++ b/src/components/JungFrau/CollectDarksPanel.tsx
@@ -37,7 +37,7 @@ export function CollectDarksPanel() {
           <Typography
             variant="h2"
             sx={{
-              color: theme.palette.primary.contrastText,
+              color: theme.palette.text.primary,
               fontSize: 24,
               fontWeight: "fontWeightBold",
             }}
@@ -62,7 +62,7 @@ export function CollectDarksPanel() {
             <Typography
               variant="body1"
               sx={{
-                color: theme.palette.primary.contrastText,
+                color: theme.palette.text.primary,
                 fontSize: 20,
                 fontWeight: "fontWeightBold",
               }}
@@ -99,7 +99,7 @@ export function CollectDarksPanel() {
             <Typography
               variant="body1"
               sx={{
-                color: theme.palette.primary.contrastText,
+                color: theme.palette.text.primary,
                 fontSize: 20,
                 fontWeight: "fontWeightBold",
               }}

--- a/src/components/JungFrau/CollectionSetupJf.tsx
+++ b/src/components/JungFrau/CollectionSetupJf.tsx
@@ -62,7 +62,7 @@ export function CollectionSetupJf() {
         <Typography
           variant="h2"
           sx={{
-            color: theme.palette.primary.contrastText,
+            color: theme.palette.text.primary,
             fontSize: 24,
             fontWeight: "fontWeightBold",
           }}


### PR DESCRIPTION
`primary.contrastText` was not theme-aware.

From:
<img width="1723" height="1016" alt="image" src="https://github.com/user-attachments/assets/0b7497e0-a731-400a-8da2-1ecae489507d" />

To:
<img width="1723" height="1016" alt="image" src="https://github.com/user-attachments/assets/3dce1f64-2ce1-4fa1-bb71-1a3825e34dce" />
<img width="1723" height="1016" alt="image" src="https://github.com/user-attachments/assets/1cbf9d2c-9e2f-4074-b8e9-364604e9327c" />
